### PR TITLE
refactor(internal-utils): improve versioning epxort

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "turbo": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "vitest-fetch-mock": "catalog:"
+    "msw": "^2.7.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/adapters/eslint.config.js
+++ b/packages/adapters/eslint.config.js
@@ -3,6 +3,6 @@ import { luxass } from "@luxass/eslint-config";
 
 export default luxass({
   type: "lib",
-},{
+}, {
   ignores: ["**/*.md"],
 });

--- a/packages/adapters/eslint.config.js
+++ b/packages/adapters/eslint.config.js
@@ -3,17 +3,6 @@ import { luxass } from "@luxass/eslint-config";
 
 export default luxass({
   type: "lib",
-}, {
-  files: ["!**/*.test.ts"],
-  rules: {
-    "no-restricted-globals": [
-      "error",
-      {
-        name: "fetchMock",
-        message: "using fetchMock in non-test files is not allowed",
-      },
-    ],
-  },
-}, {
+},{
   ignores: ["**/*.md"],
 });

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -4,16 +4,5 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "app",
 }, {
-  files: ["!**/*.test.ts"],
-  rules: {
-    "no-restricted-globals": [
-      "error",
-      {
-        name: "fetchMock",
-        message: "using fetchMock in non-test files is not allowed",
-      },
-    ],
-  },
-}, {
   ignores: ["**/*.md"],
 });

--- a/packages/internal-utils/eslint.config.js
+++ b/packages/internal-utils/eslint.config.js
@@ -4,16 +4,5 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
 }, {
-  files: ["!**/*.test.ts"],
-  rules: {
-    "no-restricted-globals": [
-      "error",
-      {
-        name: "fetchMock",
-        message: "using fetchMock in non-test files is not allowed",
-      },
-    ],
-  },
-}, {
   ignores: ["**/*.md"],
 });

--- a/packages/internal-utils/src/cache.ts
+++ b/packages/internal-utils/src/cache.ts
@@ -184,6 +184,7 @@ export async function fetchCache<TData>(url: string, options: FetchCacheOptions<
   if (!response.ok) {
     throw new Error(`failed to fetch: url=(${url}) status=(${response.status})`);
   }
+
   // TODO: don't use .text if encoding is binary or something like that
   const data = await response.text();
   const parsedData = parser(data);

--- a/packages/internal-utils/src/versions.ts
+++ b/packages/internal-utils/src/versions.ts
@@ -44,41 +44,40 @@ export interface DraftVersion {
  * @returns {Promise<DraftVersion | null>} A Promise that resolves to the current draft version string, or null if not found
  */
 export async function getCurrentDraftVersion(): Promise<DraftVersion | null> {
-  try {
-    const [draftText, emojiText] = await Promise.all([
-      "https://unicode.org/Public/draft/ReadMe.txt",
-      "https://unicode.org/Public/draft/emoji/ReadMe.txt",
-    ].map(async (url) => {
-      const res = await fetch(url);
+  const [draftText, emojiText] = await Promise.all([
+    "https://unicode.org/Public/draft/ReadMe.txt",
+    "https://unicode.org/Public/draft/emoji/ReadMe.txt",
+  ].map(async (url) => {
+    const res = await fetch(url);
 
-      if (!res.ok) {
-        throw new Error(`failed to fetch ${url}: ${res.statusText}`);
-      }
-
-      return res.text();
-    }));
-
-    const rootVersion = extractVersionFromReadme(draftText);
-    const emojiVersion = extractVersionFromReadme(emojiText);
-
-    if (rootVersion == null || emojiVersion == null) {
-      throw new Error("failed to extract draft version");
+    if (!res.ok) {
+      throw new Error(`failed to fetch ${url}: ${res.status}`);
     }
 
-    // the emoji version is only using major.minor format.
-    // so, we will need to add the last 0 to the version.
-    // if they don't match the major and minor version, we will throw an error.
-    if (semver.major(rootVersion) !== semver.major(`${emojiVersion}.0`) || semver.minor(rootVersion) !== semver.minor(`${emojiVersion}.0`)) {
-      throw new Error("draft versions do not match");
-    }
+    return res.text();
+  }));
 
-    return {
-      emoji_version: emojiVersion,
-      unicode_version: rootVersion,
-    };
-  } catch {
-    return null;
+  console.warn("draftText", draftText);
+  console.warn("emojiText", emojiText);
+
+  const rootVersion = extractVersionFromReadme(draftText);
+  const emojiVersion = extractVersionFromReadme(emojiText);
+
+  if (rootVersion == null || emojiVersion == null) {
+    throw new Error("failed to extract draft version");
   }
+
+  // the emoji version is only using major.minor format.
+  // so, we will need to add the last 0 to the version.
+  // if they don't match the major and minor version, we will throw an error.
+  if (semver.major(rootVersion) !== semver.major(`${emojiVersion}.0`) || semver.minor(rootVersion) !== semver.minor(`${emojiVersion}.0`)) {
+    throw new Error("draft versions do not match");
+  }
+
+  return {
+    emoji_version: emojiVersion,
+    unicode_version: rootVersion,
+  };
 }
 
 /**
@@ -219,7 +218,7 @@ export async function getAllEmojiVersions(): Promise<EmojiSpecRecord[]> {
     const res = await fetch(url);
 
     if (!res.ok) {
-      throw new Error(`failed to fetch ${url}: ${res.statusText}`);
+      throw new Error(`[versions]: failed to fetch ${url}: ${res.statusText}`);
     }
 
     return res.text();
@@ -246,7 +245,7 @@ export async function getAllEmojiVersions(): Promise<EmojiSpecRecord[]> {
   const draft = await getCurrentDraftVersion();
 
   if (draft == null) {
-    throw new Error("failed to fetch draft version");
+    throw new Error("failed to extract draft version");
   }
 
   const versions: EmojiSpecRecord[] = [];

--- a/packages/internal-utils/src/versions.ts
+++ b/packages/internal-utils/src/versions.ts
@@ -57,9 +57,6 @@ export async function getCurrentDraftVersion(): Promise<DraftVersion | null> {
     return res.text();
   }));
 
-  console.warn("draftText", draftText);
-  console.warn("emojiText", emojiText);
-
   const rootVersion = extractVersionFromReadme(draftText);
   const emojiVersion = extractVersionFromReadme(emojiText);
 

--- a/packages/internal-utils/test/cache.test.ts
+++ b/packages/internal-utils/test/cache.test.ts
@@ -1,7 +1,7 @@
 import type { CacheMeta } from "../src/cache";
 import fs from "fs-extra";
-import { http, HttpResponse } from "msw";
-import { mockFetch, msw_server } from "test/msw-utils/msw";
+import { HttpResponse } from "msw";
+import { mockFetch } from "test/msw-utils/msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testdir } from "vitest-testdirs";
 import { createCacheKeyFromUrl, fetchCache, readCache, readCacheMeta, writeCache } from "../src/cache";

--- a/packages/internal-utils/test/cache.test.ts
+++ b/packages/internal-utils/test/cache.test.ts
@@ -1,5 +1,7 @@
 import type { CacheMeta } from "../src/cache";
 import fs from "fs-extra";
+import { http, HttpResponse } from "msw";
+import { mockFetch, msw_server } from "test/msw-utils/msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testdir } from "vitest-testdirs";
 import { createCacheKeyFromUrl, fetchCache, readCache, readCacheMeta, writeCache } from "../src/cache";
@@ -271,8 +273,6 @@ describe("fetchCache", () => {
     const result = await fetchCache<Record<string, string>>("https://mojis.dev", options);
 
     expect(result).toEqual(testData);
-
-    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("should fetch and cache new data when bypass is true", async () => {
@@ -285,12 +285,13 @@ describe("fetchCache", () => {
       bypassCache: true,
     };
 
-    fetchMock.mockResponse(rawData);
+    mockFetch("https://mojis.dev", "get", () => {
+      return HttpResponse.json(rawData, { status: 200 });
+    });
 
     const result = await fetchCache<Record<string, string>>("https://mojis.dev", options);
 
     expect(result).toEqual(parsedData);
-    expect(fetch).toHaveBeenCalledWith("https://mojis.dev", undefined);
     expect(fs.writeFile).toHaveBeenCalled();
   });
 
@@ -301,7 +302,9 @@ describe("fetchCache", () => {
       bypassCache: true,
     };
 
-    fetchMock.mockResponse("Not Found", { status: 404 });
+    mockFetch("https://mojis.dev/", "get", () => {
+      return new HttpResponse("Not Found", { status: 404 });
+    });
 
     await expect(fetchCache("https://mojis.dev", options))
       .rejects
@@ -317,7 +320,9 @@ describe("fetchCache", () => {
       bypassCache: true,
     };
 
-    fetchMock.mockResponse(rawData);
+    mockFetch("https://mojis.dev", "get", () => {
+      return HttpResponse.text(rawData, { status: 200 });
+    });
 
     const result = await fetchCache("https://mojis.dev", options);
 

--- a/packages/internal-utils/test/cache.test.ts
+++ b/packages/internal-utils/test/cache.test.ts
@@ -1,9 +1,9 @@
 import type { CacheMeta } from "../src/cache";
 import fs from "fs-extra";
 import { HttpResponse } from "msw";
-import { mockFetch } from "test/msw-utils/msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testdir } from "vitest-testdirs";
+import { mockFetch } from "../../../test/msw-utils/msw";
 import { createCacheKeyFromUrl, fetchCache, readCache, readCacheMeta, writeCache } from "../src/cache";
 
 vi.mock("fs-extra", {
@@ -286,7 +286,7 @@ describe("fetchCache", () => {
     };
 
     mockFetch("https://mojis.dev", "get", () => {
-      return HttpResponse.json(rawData, { status: 200 });
+      return HttpResponse.text(rawData, { status: 200 });
     });
 
     const result = await fetchCache<Record<string, string>>("https://mojis.dev", options);

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -305,15 +305,13 @@ describe("all emoji versions", () => {
     await expect(() => getAllEmojiVersions()).rejects.toThrow("failed to fetch root or emoji page");
   });
 
-  // it("should return an empty array if no versions are found", async () => {
-  //   fetchMock
-  //     .mockResponseIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
-  //     .mockResponseIf("https://unicode.org/Public/draft/emoji/ReadMe.txt", "Unicode Emoji, Version 15.1");
+  it("should throw if fetch returns invalid data", async () => {
+    mockFetch("https://unicode.org/Public/", "get", () => {
+      return HttpResponse.text("Not Found", { status: 400 });
+    });
 
-  //   const result = await getAllEmojiVersions();
-
-  //   console.log(result);
-  // });
+    await expect(() => getAllEmojiVersions()).rejects.toThrow("failed to fetch root or emoji page");
+  });
 });
 
 describe("draft", () => {
@@ -349,5 +347,16 @@ describe("draft", () => {
     });
 
     await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to fetch https://unicode.org/Public/draft/ReadMe.txt: 404");
+  });
+
+  it("should throw if emoji version is invalid", async () => {
+    mockFetch("https://unicode.org/Public/draft/ReadMe.txt", "get", () => {
+      return HttpResponse.text("");
+    });
+    mockFetch("https://unicode.org/Public/draft/emoji/ReadMe.txt", "get", () => {
+      return HttpResponse.text("");
+    });
+
+    await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to extract draft version");
   });
 });

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -12,41 +12,6 @@ import {
   toSemverCompatible,
 } from "../src/versions";
 
-describe("getCurrentDraftVersion", () => {
-  it("returns draft versions when fetches succeed and versions match", async () => {
-    fetchMock
-      .mockResponseOnceIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
-      .mockResponseOnceIf("https://unicode.org/Public/draft/emoji/ReadMe.txt", "Unicode Emoji, Version 15.1");
-
-    const result = await getCurrentDraftVersion();
-    expect(result).toEqual({
-      emoji_version: "15.1",
-      unicode_version: "15.1.0",
-    });
-  });
-
-  it("returns null when fetch fails", async () => {
-    fetchMock.mockResponse("Not Found", { status: 404 });
-
-    expect(await getCurrentDraftVersion()).toBeNull();
-  });
-
-  it("returns null when versions do not match", async () => {
-    fetchMock
-      .mockResponseOnceIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
-      .mockResponseOnceIf("https://unicode.org/Public/draft/emoji/ReadMe.txt", "Unicode Emoji, Version 15.0");
-
-    expect(await getCurrentDraftVersion()).toBeNull();
-  });
-
-  it("returns null when version extraction fails", async () => {
-    fetchMock
-      .mockResponse("Invalid version format", { status: 200 });
-
-    expect(await getCurrentDraftVersion()).toBeNull();
-  });
-});
-
 describe("extractVersionFromReadme", () => {
   it.each([
     { input: "Version 15.1.0 of the Unicode Standard", expected: "15.1.0" },
@@ -274,7 +239,7 @@ describe("extractUnicodeVersion", () => {
   });
 });
 
-describe("isEmojiVersionAllowed", () => {
+describe("is emoji version allowed", () => {
   it.each([
     { version: "11.0.0", expected: true },
     { version: "12.0.0", expected: true },
@@ -325,5 +290,40 @@ describe("isEmojiVersionAllowed", () => {
     { version: "5.0.1", expected: false },
   ])("returns false for patch versions within 1-5: $version", async ({ version, expected }) => {
     expect(await isEmojiVersionAllowed(version)).toBe(expected);
+  });
+});
+
+describe("draft", () => {
+  it("returns draft versions when fetches succeed and versions match", async () => {
+    fetchMock
+      .mockResponseOnceIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
+      .mockResponseOnceIf("https://unicode.org/Public/draft/emoji/ReadMe.txt", "Unicode Emoji, Version 15.1");
+
+    const result = await getCurrentDraftVersion();
+    expect(result).toEqual({
+      emoji_version: "15.1",
+      unicode_version: "15.1.0",
+    });
+  });
+
+  it("returns null when fetch fails", async () => {
+    fetchMock.mockResponse("Not Found", { status: 404 });
+
+    expect(await getCurrentDraftVersion()).toBeNull();
+  });
+
+  it("returns null when versions do not match", async () => {
+    fetchMock
+      .mockResponseOnceIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
+      .mockResponseOnceIf("https://unicode.org/Public/draft/emoji/ReadMe.txt", "Unicode Emoji, Version 15.0");
+
+    expect(await getCurrentDraftVersion()).toBeNull();
+  });
+
+  it("returns null when version extraction fails", async () => {
+    fetchMock
+      .mockResponse("Invalid version format", { status: 200 });
+
+    expect(await getCurrentDraftVersion()).toBeNull();
   });
 });

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -12,7 +12,7 @@ import {
   toSemverCompatible,
 } from "../src/versions";
 
-describe("get draft version", () => {
+describe("getCurrentDraftVersion", () => {
   it("returns draft versions when fetches succeed and versions match", async () => {
     fetchMock
       .mockResponseOnceIf("https://unicode.org/Public/draft/ReadMe.txt", "Version 15.1.0 of the Unicode Standard")
@@ -47,7 +47,7 @@ describe("get draft version", () => {
   });
 });
 
-describe("extract version", () => {
+describe("extractVersionFromReadme", () => {
   it.each([
     { input: "Version 15.1.0 of the Unicode Standard", expected: "15.1.0" },
     { input: "Version 15.1 of the Unicode Standard", expected: "15.1" },
@@ -79,7 +79,7 @@ describe("extract version", () => {
     });
   });
 
-  describe("extract emoji version", () => {
+  describe("extractEmojiVersion", () => {
     it.each([
       { input: "E14.0", expected: "14.0" },
       { input: "E15.1", expected: "15.1" },

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -7,7 +7,7 @@ import {
   extractVersionFromReadme,
   getCurrentDraftVersion,
   getLatestEmojiVersion,
-  isEmojiVersionValid,
+  isEmojiVersionAllowed,
   mapEmojiVersionToUnicodeVersion,
   toSemverCompatible,
 } from "../src/versions";
@@ -277,7 +277,7 @@ describe("extract unicode version", () => {
   });
 });
 
-describe("is emoji version valid", () => {
+describe("isEmojiVersionAllowed", () => {
   it.each([
     { version: "11.0.0", expected: true },
     { version: "12.0.0", expected: true },
@@ -286,8 +286,8 @@ describe("is emoji version valid", () => {
     { version: "15.0.0", expected: true },
     { version: "15.1.0", expected: true },
     { version: "16.0.0", expected: true },
-  ])("should return true for valid emoji versions >= 11.0.0 (version: $version)", async ({ version, expected }) => {
-    expect(await isEmojiVersionValid(version)).toBe(expected);
+  ])("returns true for major version >= 11: $version", async ({ version, expected }) => {
+    expect(await isEmojiVersionAllowed(version)).toBe(expected);
   });
 
   it.each([
@@ -296,8 +296,8 @@ describe("is emoji version valid", () => {
     { version: "3.0.0", expected: true },
     { version: "4.0.0", expected: true },
     { version: "5.0.0", expected: true },
-  ])("should return true for valid emoji versions 1.0.0 - 5.0.0 (version: $version)", async ({ version, expected }) => {
-    expect(await isEmojiVersionValid(version)).toBe(expected);
+  ])("returns true for major versions 1-5: $version", async ({ version, expected }) => {
+    expect(await isEmojiVersionAllowed(version)).toBe(expected);
   });
 
   it.each([
@@ -306,8 +306,8 @@ describe("is emoji version valid", () => {
     { version: "8.0.0", expected: false },
     { version: "9.0.0", expected: false },
     { version: "10.0.0", expected: false },
-  ])("should return false for invalid emoji versions 6.0.0 - 10.0.0 (version: $version)", async ({ version, expected }) => {
-    expect(await isEmojiVersionValid(version)).toBe(expected);
+  ])("returns false for major versions 6-10: $version", async ({ version, expected }) => {
+    expect(await isEmojiVersionAllowed(version)).toBe(expected);
   });
 
   it.each([
@@ -316,8 +316,8 @@ describe("is emoji version valid", () => {
     { version: "3.1.0", expected: false },
     { version: "4.1.0", expected: false },
     { version: "5.1.0", expected: false },
-  ])("should return false for invalid emoji versions 1.1.0 - 5.1.0 (version: $version)", async ({ version, expected }) => {
-    expect(await isEmojiVersionValid(version)).toBe(expected);
+  ])("returns false for minor versions within 1-5: $version", async ({ version, expected }) => {
+    expect(await isEmojiVersionAllowed(version)).toBe(expected);
   });
 
   it.each([
@@ -326,7 +326,7 @@ describe("is emoji version valid", () => {
     { version: "3.0.1", expected: false },
     { version: "4.0.1", expected: false },
     { version: "5.0.1", expected: false },
-  ])("should return false for invalid emoji versions 1.0.1 - 5.0.1 (version: $version)", async ({ version, expected }) => {
-    expect(await isEmojiVersionValid(version)).toBe(expected);
+  ])("returns false for patch versions within 1-5: $version", async ({ version, expected }) => {
+    expect(await isEmojiVersionAllowed(version)).toBe(expected);
   });
 });

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -106,18 +106,18 @@ describe("extract version", () => {
   });
 });
 
-describe("map emoji version to unicode version", () => {
+describe("mapEmojiVersionToUnicode", () => {
   it.each([
     { input: "1.0", expected: "8.0" },
     { input: "15.0", expected: "15.0" },
     { input: "15.1", expected: "15.1" },
     { input: "13.1", expected: "13.0" },
-  ])("should map emoji version to unicode version (input: $input, expected: $expected)", ({ input, expected }) => {
+  ])("$input -> $expected", ({ input, expected }) => {
     expect(mapEmojiVersionToUnicodeVersion(input)).toBe(expected);
   });
 });
 
-describe("convert to semver compatible version", () => {
+describe("toSemverCompatible", () => {
   it.each([
     { input: "1.0", expected: "1.0.0" },
     { input: "15.0", expected: "15.0.0" },
@@ -129,12 +129,9 @@ describe("convert to semver compatible version", () => {
     { input: "3.1.4-alpha", expected: "3.1.4" }, // extra characters
     { input: "1.0.0+build.123", expected: "1.0.0" }, // build metadata
     { input: "1.2.0-beta.1", expected: "1.2.0" }, // prerelease
-  ])(
-    "should convert emoji version to semver compatible version (input: $input, expected: $expected)",
-    ({ input, expected }) => {
-      expect(toSemverCompatible(input)).toBe(expected);
-    },
-  );
+  ])("convert $input to semver compatible version $expected", ({ input, expected }) => {
+    expect(toSemverCompatible(input)).toBe(expected);
+  });
 
   it.each([
     { input: "invalid-version", expected: null },
@@ -142,14 +139,14 @@ describe("convert to semver compatible version", () => {
     { input: null as any, expected: null },
     { input: undefined as any, expected: null },
   ])(
-    "should return null when input is not coercible (input: $input)",
+    "should return null for invalid input: $input",
     ({ input, expected }) => {
       expect(toSemverCompatible(input)).toBe(expected);
     },
   );
 });
 
-describe("get latest emoji version", () => {
+describe("getLatestEmojiVersion", () => {
   it("returns the latest non-draft version", () => {
     const versions: EmojiSpecRecord[] = [
       { emoji_version: "15.1", unicode_version: "15.1", draft: false },
@@ -239,7 +236,7 @@ describe("get latest emoji version", () => {
   });
 });
 
-describe("extract unicode version", () => {
+describe("extractUnicodeVersion", () => {
   it("should return null if emojiVersion is null", () => {
     expect(extractUnicodeVersion(null)).toBeNull();
   });
@@ -257,7 +254,7 @@ describe("extract unicode version", () => {
     expect(extractUnicodeVersion("11.0.0", "invalid")).toBe("11.0.0");
   });
 
-  it("should return the smaller version if both emojiVersion and unicodeVersion are valid and emojiVersion is >= 11.0.0", () => {
+  it("returns the lower version for valid emoji and unicode versions (emoji >= 11)", () => {
     expect(extractUnicodeVersion("11.0.0", "12.0.0")).toBe("11.0.0");
     expect(extractUnicodeVersion("12.0.0", "11.0.0")).toBe("11.0.0");
   });

--- a/packages/parsers/eslint.config.js
+++ b/packages/parsers/eslint.config.js
@@ -4,16 +4,5 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
 }, {
-  files: ["!**/*.test.ts"],
-  rules: {
-    "no-restricted-globals": [
-      "error",
-      {
-        name: "fetchMock",
-        message: "using fetchMock in non-test files is not allowed",
-      },
-    ],
-  },
-}, {
   ignores: ["**/*.md"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ catalogs:
     vitest:
       specifier: ^3.0.7
       version: 3.0.8
-    vitest-fetch-mock:
-      specifier: ^0.4.4
-      version: 0.4.5
     vitest-testdirs:
       specifier: ^2.1.1
       version: 2.1.1
@@ -95,6 +92,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.21.0
+      msw:
+        specifier: ^2.7.3
+        version: 2.7.3(@types/node@22.13.9)(typescript@5.8.2)
       turbo:
         specifier: 'catalog:'
         version: 2.4.4
@@ -103,10 +103,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
-      vitest-fetch-mock:
-        specifier: 'catalog:'
-        version: 0.4.5(vitest@3.0.8)
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0)
 
   packages/adapters:
     dependencies:
@@ -277,6 +274,15 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bundled-es-modules/cookie@2.0.1':
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
   '@changesets/apply-release-plan@7.0.10':
     resolution: {integrity: sha512-wNyeIJ3yDsVspYvHnEz1xQDq18D9ifed3lI+wxRQRK4pArUcuHgCTrHv0QRnnwjhVCQACxZ+CBih3wgOct6UXw==}
@@ -576,6 +582,37 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/confirm@5.1.7':
+    resolution: {integrity: sha512-Xrfbrw9eSiHb+GsesO8TQIeHSMTP0xyvTCeeYevgZ4sKW+iz9w/47bgfG9b0niQm+xaLY2EWPBINUPldLwvYiw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.8':
+    resolution: {integrity: sha512-HpAqR8y715zPpM9e/9Q+N88bnGwqqL8ePgZ0SMv/s3673JLMv3bIkoivGmjPqXlEgisUksSXibweQccUwEx4qQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.11':
+    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.5':
+    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -642,6 +679,10 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mswjs/interceptors@0.37.6':
+    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
+    engines: {node: '>=18'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -653,6 +694,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -766,6 +816,9 @@ packages:
     peerDependencies:
       eslint: '>=9.0.0'
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -801,6 +854,12 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/statuses@2.0.5':
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -946,6 +1005,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1076,6 +1139,10 @@ packages:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -1107,6 +1174,10 @@ packages:
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-js-compat@3.41.0:
     resolution: {integrity: sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==}
@@ -1566,6 +1637,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.10.0:
+    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1573,6 +1648,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -1635,6 +1713,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -1936,6 +2017,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.7.3:
+    resolution: {integrity: sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -1984,6 +2079,9 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -2058,6 +2156,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2134,12 +2235,18 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quansync@0.2.8:
     resolution: {integrity: sha512-4+saucphJMazjt7iOM27mbFCk+D9dd/zmgMDCzRZ8MEoBfYp7lAvoN38et/phRQF6wOPMy/OROBGgoWeSKyluA==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2182,6 +2289,9 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2287,8 +2397,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2403,6 +2520,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -2482,6 +2603,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
   type-fest@4.37.0:
     resolution: {integrity: sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==}
     engines: {node: '>=16'}
@@ -2521,6 +2646,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2533,6 +2662,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2584,12 +2716,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  vitest-fetch-mock@0.4.5:
-    resolution: {integrity: sha512-nhWdCQIGtaSEUVl96pMm0WggyDGPDv5FUy/Q9Hx3cs2RGmh3Q/uRsLClGbdG3kXBkJ3br5yTUjB2MeW25TwdOA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      vitest: '>=2.0.0'
 
   vitest-testdirs@2.1.1:
     resolution: {integrity: sha512-1bVjra7vT07fFasVYmpWYBYvvGBogrvjBOBk3UVhCD4ESwhU+CcLBEnpo21jBDgM1KWvWQsg3HZgerMnnBDcsQ==}
@@ -2665,6 +2791,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -2701,6 +2831,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
@@ -2744,6 +2878,19 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bundled-es-modules/cookie@2.0.1':
+    dependencies:
+      cookie: 0.7.2
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.1
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
 
   '@changesets/apply-release-plan@7.0.10':
     dependencies:
@@ -3073,6 +3220,32 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
+  '@inquirer/confirm@5.1.7(@types/node@22.13.9)':
+    dependencies:
+      '@inquirer/core': 10.1.8(@types/node@22.13.9)
+      '@inquirer/type': 3.0.5(@types/node@22.13.9)
+    optionalDependencies:
+      '@types/node': 22.13.9
+
+  '@inquirer/core@10.1.8(@types/node@22.13.9)':
+    dependencies:
+      '@inquirer/figures': 1.0.11
+      '@inquirer/type': 3.0.5(@types/node@22.13.9)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 22.13.9
+
+  '@inquirer/figures@1.0.11': {}
+
+  '@inquirer/type@3.0.5(@types/node@22.13.9)':
+    optionalDependencies:
+      '@types/node': 22.13.9
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3159,6 +3332,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mswjs/interceptors@0.37.6':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3170,6 +3352,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3247,6 +3438,8 @@ snapshots:
       - supports-color
       - typescript
 
+  '@types/cookie@0.6.0': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -3281,6 +3474,10 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/semver@7.5.8': {}
+
+  '@types/statuses@2.0.5': {}
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
 
@@ -3381,7 +3578,7 @@ snapshots:
       std-env: 3.8.1
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3391,7 +3588,7 @@ snapshots:
       eslint: 9.21.0
     optionalDependencies:
       typescript: 5.8.2
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0)
 
   '@vitest/expect@3.0.8':
     dependencies:
@@ -3400,12 +3597,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@6.2.1(@types/node@22.13.9)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.2.1(@types/node@22.13.9)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
+      msw: 2.7.3(@types/node@22.13.9)(typescript@5.8.2)
       vite: 6.2.1(@types/node@22.13.9)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.8':
@@ -3436,7 +3634,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0)
 
   '@vitest/utils@3.0.8':
     dependencies:
@@ -3490,6 +3688,10 @@ snapshots:
       uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -3616,6 +3818,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  cli-width@4.1.0: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -3639,6 +3843,8 @@ snapshots:
   confbox@0.2.1: {}
 
   consola@3.4.0: {}
+
+  cookie@0.7.2: {}
 
   core-js-compat@3.41.0:
     dependencies:
@@ -4193,11 +4399,15 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.10.0: {}
+
   has-flag@4.0.0: {}
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -4250,6 +4460,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -4714,6 +4926,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.7(@types/node@22.13.9)
+      '@mswjs/interceptors': 0.37.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.10.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.37.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -4756,6 +4995,8 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  outvariant@1.4.3: {}
 
   p-filter@2.1.0:
     dependencies:
@@ -4828,6 +5069,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -4880,9 +5123,15 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
 
   quansync@0.2.8: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -4927,6 +5176,8 @@ snapshots:
       jsesc: 3.0.2
 
   require-directory@2.1.1: {}
+
+  requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5039,7 +5290,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.1: {}
+
   std-env@3.8.1: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5145,6 +5400,13 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
 
   tr46@1.0.1:
@@ -5219,6 +5481,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.21.3: {}
+
   type-fest@4.37.0: {}
 
   typescript@5.8.2: {}
@@ -5252,6 +5516,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.4):
@@ -5263,6 +5529,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 
@@ -5302,19 +5573,15 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.7.0
 
-  vitest-fetch-mock@0.4.5(vitest@3.0.8):
-    dependencies:
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
-
   vitest-testdirs@2.1.1(vitest@3.0.8):
     dependencies:
       testdirs: 0.1.4
-      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0)
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0)
 
-  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(yaml@2.7.0):
+  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@3.0.8)(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@6.2.1(@types/node@22.13.9)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.8(msw@2.7.3(@types/node@22.13.9)(typescript@5.8.2))(vite@6.2.1(@types/node@22.13.9)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -5396,6 +5663,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5432,6 +5705,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.2: {}
 
   zod@3.24.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,6 @@ catalog:
   turbo: ^2.4.4
   typescript: ^5.8.2
   vitest: ^3.0.7
-  vitest-fetch-mock: ^0.4.4
   vitest-testdirs: ^2.1.1
   yargs: ^17.7.2
   zod: ^3.24.2

--- a/test/msw-utils/msw.ts
+++ b/test/msw-utils/msw.ts
@@ -1,0 +1,17 @@
+import { http, type HttpResponseResolver } from "msw";
+import { setupServer } from "msw/node";
+
+export const restHandlers = []
+
+export const msw_server = setupServer(...restHandlers)
+
+
+type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | "options"
+
+export function mockFetch(url: string, method: Method, resolver: HttpResponseResolver) {
+  msw_server.use(
+    http[method](url, resolver)
+  )
+}
+
+export { http };

--- a/test/setup/fetch-mock.ts
+++ b/test/setup/fetch-mock.ts
@@ -1,6 +1,0 @@
-import { vi } from "vitest";
-import createFetchMock from "vitest-fetch-mock";
-
-const fetchMocker = createFetchMock(vi);
-
-fetchMocker.enableMocks();

--- a/test/setup/msw.ts
+++ b/test/setup/msw.ts
@@ -1,10 +1,5 @@
 import { afterAll, afterEach, beforeAll } from "vitest";
-import { setupServer } from "msw/node";
-export { http } from "msw"
-
-export const restHandlers = []
-
-export const msw_server = setupServer(...restHandlers)
+import { msw_server } from "../msw-utils/msw";
 
 beforeAll(() => msw_server.listen({ onUnhandledRequest: "warn" }))
 afterAll(() => msw_server.close())

--- a/test/setup/msw.ts
+++ b/test/setup/msw.ts
@@ -1,0 +1,12 @@
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { setupServer } from "msw/node";
+export { http } from "msw"
+
+export const restHandlers = []
+
+export const msw_server = setupServer(...restHandlers)
+
+beforeAll(() => msw_server.listen({ onUnhandledRequest: "warn" }))
+afterAll(() => msw_server.close())
+afterEach(() => msw_server.resetHandlers())
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,9 +11,6 @@
       "@mojis/internal-utils/constants": ["./packages/internal-utils/src/constants"],
       "@mojis/adapters": ["./packages/adapters/src/index.ts"],
       "@mojis/parsers": ["./packages/parsers/src/index.ts"],
-    },
-    "types": [
-      "vitest-fetch-mock"
-    ]
+    }
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,8 @@ const aliases = readdirSync(new URL("./packages", import.meta.url).pathname)
     {});
 
 const hiddenLogs = [
-  "[shortcodes]"
+  "[shortcodes]",
+  "[versions]"
 ]
 
 export default defineConfig({
@@ -25,7 +26,7 @@ export default defineConfig({
       include: ["**/src/**"],
     },
     setupFiles: [
-      "./test/setup/fetch-mock.ts"
+      "./test/setup/msw.ts"
     ],
     onConsoleLog(log, type) {
       if (type === "stderr") {


### PR DESCRIPTION
This PR will rewrite most of our versioning export from `@mojis/internal-utils`, and will also remove our dependency on "vitest-fetch-mock", so we can use "msw" instead.

We just need to flatten some of issues with msw out, since we will try and use as little as possible of default handlers and instead use co-located handlers.