### PR TITLE
refactor: use unicode-proxy

### DIFF
--- a/.changeset/chatty-hoops-divide.md
+++ b/.changeset/chatty-hoops-divide.md
@@ -1,0 +1,7 @@
+---
+"@mojis/internal-utils": patch
+"@mojis/adapters": patch
+"@mojis/parsers": patch
+---
+
+refactor: use unicode-proxy

--- a/packages/adapters/src/handlers/metadata.ts
+++ b/packages/adapters/src/handlers/metadata.ts
@@ -28,7 +28,7 @@ export const baseMetadataHandler = defineAdapterHandler({
   },
   urls: (ctx) => {
     return {
-      url: `https://unicode.org/Public/emoji/${ctx.emoji_version}/emoji-test.txt`,
+      url: `https://unicode-proxy.mojis.dev/proxy/emoji/${ctx.emoji_version}/emoji-test.txt`,
       cacheKey: `v${ctx.emoji_version}/metadata`,
     };
   },

--- a/packages/adapters/src/handlers/sequence.ts
+++ b/packages/adapters/src/handlers/sequence.ts
@@ -38,12 +38,12 @@ export const baseSequenceHandler = defineAdapterHandler({
     return [
       {
         key: "sequences",
-        url: `https://unicode.org/Public/emoji/${emoji_version}/emoji-sequences.txt`,
+        url: `https://unicode-proxy.mojis.dev/proxy/emoji/${emoji_version}/emoji-sequences.txt`,
         cacheKey: `v${emoji_version}/sequences`,
       },
       {
         key: "zwj",
-        url: `https://unicode.org/Public/emoji/${emoji_version}/emoji-zwj-sequences.txt`,
+        url: `https://unicode-proxy.mojis.dev/proxy/emoji/${emoji_version}/emoji-zwj-sequences.txt`,
         cacheKey: `v${emoji_version}/zwj-sequences`,
       },
     ];

--- a/packages/adapters/src/handlers/unicode-names.ts
+++ b/packages/adapters/src/handlers/unicode-names.ts
@@ -1,11 +1,11 @@
 import { defineAdapterHandler } from "../define";
 
 const MAPPINGS = {
-  "1.0": "https://unicode.org/Public/1.1-Update/UnicodeData-1.1.5.txt",
-  "2.0": "https://unicode.org/Public/2.0-Update/UnicodeData-2.0.14.txt",
-  "3.0": "https://unicode.org/Public/3.0-Update1/UnicodeData-3.0.1.txt",
-  "4.0": "https://unicode.org/Public/4.0-Update1/UnicodeData-4.0.1.txt",
-  "13.1": "https://unicode.org/Public/13.0.0/ucd/UnicodeData.txt",
+  "1.0": "https://unicode-proxy.mojis.dev/proxy/1.1-Update/UnicodeData-1.1.5.txt",
+  "2.0": "https://unicode-proxy.mojis.dev/proxy/2.0-Update/UnicodeData-2.0.14.txt",
+  "3.0": "https://unicode-proxy.mojis.dev/proxy/3.0-Update1/UnicodeData-3.0.1.txt",
+  "4.0": "https://unicode-proxy.mojis.dev/proxy/4.0-Update1/UnicodeData-4.0.1.txt",
+  "13.1": "https://unicode-proxy.mojis.dev/proxy/13.0.0/ucd/UnicodeData.txt",
 } as Record<string, string>;
 
 export const unicodeNamesHandler = defineAdapterHandler({
@@ -16,7 +16,7 @@ export const unicodeNamesHandler = defineAdapterHandler({
     separator: ";",
   },
   urls: ({ emoji_version }) => {
-    return MAPPINGS[emoji_version] || `https://unicode.org/Public/${emoji_version}.0/ucd/UnicodeData.txt`;
+    return MAPPINGS[emoji_version] || `https://unicode-proxy.mojis.dev/proxy/${emoji_version}.0/ucd/UnicodeData.txt`;
   },
   transform: (_, data) => {
     const result: Record<string, string> = {};

--- a/packages/adapters/src/handlers/variation.ts
+++ b/packages/adapters/src/handlers/variation.ts
@@ -12,13 +12,13 @@ export const baseVariationHandler = defineAdapterHandler({
   urls: (ctx) => {
     if (semver.lte(`${ctx.unicode_version}.0`, "12.1.0")) {
       return {
-        url: `https://unicode.org/Public/emoji/${ctx.emoji_version}/emoji-variation-sequences.txt`,
+        url: `https://unicode-proxy.mojis.dev/proxy/emoji/${ctx.emoji_version}/emoji-variation-sequences.txt`,
         cacheKey: `v${ctx.emoji_version}/variations`,
       };
     }
 
     return {
-      url: `https://unicode.org/Public/${ctx.unicode_version}.0/ucd/emoji/emoji-variation-sequences.txt`,
+      url: `https://unicode-proxy.mojis.dev/proxy/${ctx.unicode_version}.0/ucd/emoji/emoji-variation-sequences.txt`,
       cacheKey: `v${ctx.emoji_version}/variations`,
     };
   },

--- a/packages/internal-utils/src/versions.ts
+++ b/packages/internal-utils/src/versions.ts
@@ -46,8 +46,8 @@ export interface DraftVersion {
  */
 export async function getCurrentDraftVersion(): Promise<DraftVersion | null> {
   const [draftText, emojiText] = await Promise.all([
-    "https://unicode.org/Public/draft/ReadMe.txt",
-    "https://unicode.org/Public/draft/emoji/ReadMe.txt",
+    "https://unicode-proxy.mojis.dev/proxy/draft/ReadMe.txt",
+    "https://unicode-proxy.mojis.dev/proxy/draft/emoji/ReadMe.txt",
   ].map(async (url) => {
     const res = await fetch(url);
 
@@ -200,8 +200,8 @@ export function extractUnicodeVersion(emojiVersion: string | null, unicodeVersio
  */
 export async function getAllEmojiVersions(): Promise<EmojiSpecRecord[]> {
   const [rootResult, emojiResult] = await Promise.allSettled([
-    "https://unicode.org/Public/",
-    "https://unicode.org/Public/emoji/",
+    "https://unicode-proxy.mojis.dev/proxy/",
+    "https://unicode-proxy.mojis.dev/proxy/emoji/",
   ].map(async (url) => {
     const res = await fetch(url);
 

--- a/packages/internal-utils/test/versions.test.ts
+++ b/packages/internal-utils/test/versions.test.ts
@@ -312,7 +312,7 @@ describe("all emoji versions", () => {
   });
 
   it("should throw if fetch returns invalid data", async () => {
-    mockFetch("GET https://unicode.org/Public/", () => {
+    mockFetch("GET https://unicode-proxy.mojis.dev/proxy/", () => {
       return HttpResponse.text("Not Found", { status: 400 });
     });
 
@@ -320,7 +320,7 @@ describe("all emoji versions", () => {
   });
 
   it("should throw if empty data is returned", async () => {
-    mockFetch("GET https://unicode.org/Public/", () => {
+    mockFetch("GET https://unicode-proxy.mojis.dev/proxy/", () => {
       return HttpResponse.text("");
     });
 
@@ -331,8 +331,8 @@ describe("all emoji versions", () => {
 describe("draft", () => {
   it("returns draft versions when fetches succeed and versions match", async () => {
     mockFetch([
-      ["GET https://unicode.org/Public/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
-      ["GET https://unicode.org/Public/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.1")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.1")],
     ]);
 
     const result = await getCurrentDraftVersion();
@@ -344,8 +344,8 @@ describe("draft", () => {
 
   it("should throw when versions do not match", async () => {
     mockFetch([
-      ["GET https://unicode.org/Public/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
-      ["GET https://unicode.org/Public/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
     ]);
 
     await expect(() => getCurrentDraftVersion()).rejects.toThrow("draft versions do not match");
@@ -356,13 +356,13 @@ describe("draft", () => {
       return new HttpResponse("Not Found", { status: 404 });
     });
 
-    await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to fetch https://unicode.org/Public/draft/ReadMe.txt: 404");
+    await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to fetch https://unicode-proxy.mojis.dev/proxy/draft/ReadMe.txt: 404");
   });
 
   it("should throw if emoji version is invalid", async () => {
     mockFetch([
-      ["GET https://unicode.org/Public/draft/ReadMe.txt", () => HttpResponse.text("")],
-      ["GET https://unicode.org/Public/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.mojis.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
     ]);
 
     await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to extract draft version");

--- a/packages/parsers/scripts/update-parser-fixtures.ts
+++ b/packages/parsers/scripts/update-parser-fixtures.ts
@@ -7,7 +7,7 @@ import { traverse } from "apache-autoindex-parse/traverse";
 const root = new URL("../../../test/fixtures/parsers/", import.meta.url);
 
 async function run() {
-  const rootEntry = await traverse("https://unicode.org/Public/emoji/", {
+  const rootEntry = await traverse("https://unicode-proxy.mojis.dev/proxy/emoji/", {
     format: "F2",
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the emoji data retrieval endpoints to use a new proxy service. This change streamlines access to emoji test data, sequences, variations, and version information, ensuring improved consistency.

- **Tests**
  - Revised test cases to verify functionality with the updated data endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->