### PR TITLE
fix: update output type handling in multiple urls

### DIFF
--- a/.changeset/lovely-roses-remain.md
+++ b/.changeset/lovely-roses-remain.md
@@ -1,0 +1,5 @@
+---
+"@mojis/adapters": patch
+---
+
+fix: use correct infered type if multiple urls defined

--- a/packages/adapters/src/types.ts
+++ b/packages/adapters/src/types.ts
@@ -216,7 +216,10 @@ export interface HandleVersionBuilder<TParams extends AnyHandleVersionParams> {
     _parser: TParams["_parser"];
     _parserOptions: TParams["_parserOptions"];
     _output: TParams["_output"];
-    _outputType: TOut;
+
+    // if there are multiple urls, we set it to an array,
+    // because we don't know if aggregate is there or not
+    _outputType: TParams["_urls"] extends any[] ? TOut[] : TOut;
   }>;
 
   aggregate: <TIn extends TParams["_transform"]["out"], TOut>(

--- a/packages/adapters/test/run.test.ts
+++ b/packages/adapters/test/run.test.ts
@@ -138,7 +138,7 @@ describe("runAdapterHandler", () => {
       .urls(() => ["https://mojis.dev/run-multiple-urls/1", "https://mojis.dev/run-multiple-urls/2"])
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler1" }))
-      .output((_, data) => ({ processedBy: data[0].processed }));
+      .output((_, data) => ({ processedBy: data[0]?.processed }));
 
     const mockHandler2 = createVersionHandlerBuilder()
       .urls(() => "https://mojis.dev/run-multiple-urls/3")


### PR DESCRIPTION
This PR only fixes the infered types from output, if there are multiple urls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling for scenarios involving multiple URLs, ensuring outputs reflect the correct format.
	- Enhanced output processing with additional safety checks to prevent potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->