### PR TITLE
fix: add generics to runAdapterHandler test function

### DIFF
--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -20,7 +20,7 @@ export interface RunOverrides {
   cache?: Cache<string>;
 }
 
-const HANDLERS = {
+export const HANDLERS = {
   metadata,
   sequences,
   "unicode-names": unicodeNames,

--- a/packages/adapters/test/test-utils.ts
+++ b/packages/adapters/test/test-utils.ts
@@ -1,8 +1,9 @@
 /* eslint-disable ts/explicit-function-return-type */
 import type { Cache } from "@mojis/internal-utils";
 import type { z } from "zod";
-import type { FallbackFn, PredicateFn } from "../src/adapter-builder/types";
+import type { AnyAdapterHandler, FallbackFn, PredicateFn } from "../src/adapter-builder/types";
 import type { AdapterHandlerType } from "../src/global-types";
+import type { HANDLERS } from "../src/index";
 import type { AnyVersionHandler } from "../src/version-builder/types";
 import { createCache } from "@mojis/internal-utils";
 import { vi } from "vitest";
@@ -89,9 +90,12 @@ export async function setupAdapterTest<TOutputSchema extends z.ZodType>(options?
     ]);
   }
 
-  function runAdapterHandler(...args: Parameters<typeof runAdapterHandlerOriginal>) {
+  function runAdapterHandler<
+    TAdapterHandlerType extends AdapterHandlerType,
+    THandler extends AnyAdapterHandler = typeof HANDLERS[TAdapterHandlerType],
+  >(...args: Parameters<typeof runAdapterHandlerOriginal<TAdapterHandlerType, THandler>>) {
     const [type, ctx, opts] = args;
-    return runAdapterHandlerOriginal(type, ctx, {
+    return runAdapterHandlerOriginal<TAdapterHandlerType, THandler>(type, ctx, {
       ...opts,
       cache: cache as Cache<string>,
     });

--- a/packages/adapters/test/test-utils.ts
+++ b/packages/adapters/test/test-utils.ts
@@ -90,12 +90,11 @@ export async function setupAdapterTest<TOutputSchema extends z.ZodType>(options?
     ]);
   }
 
-  function runAdapterHandler<
-    TAdapterHandlerType extends AdapterHandlerType,
-    THandler extends AnyAdapterHandler = typeof HANDLERS[TAdapterHandlerType],
-  >(...args: Parameters<typeof runAdapterHandlerOriginal<TAdapterHandlerType, THandler>>) {
+  function runAdapterHandler<TAdapterHandlerType extends AdapterHandlerType>(
+    ...args: Parameters<typeof runAdapterHandlerOriginal<TAdapterHandlerType>>
+  ) {
     const [type, ctx, opts] = args;
-    return runAdapterHandlerOriginal<TAdapterHandlerType, THandler>(type, ctx, {
+    return runAdapterHandlerOriginal(type, ctx, {
       ...opts,
       cache: cache as Cache<string>,
     });

--- a/packages/adapters/test/test-utils.ts
+++ b/packages/adapters/test/test-utils.ts
@@ -1,9 +1,8 @@
 /* eslint-disable ts/explicit-function-return-type */
 import type { Cache } from "@mojis/internal-utils";
 import type { z } from "zod";
-import type { AnyAdapterHandler, FallbackFn, PredicateFn } from "../src/adapter-builder/types";
+import type { FallbackFn, PredicateFn } from "../src/adapter-builder/types";
 import type { AdapterHandlerType } from "../src/global-types";
-import type { HANDLERS } from "../src/index";
 import type { AnyVersionHandler } from "../src/version-builder/types";
 import { createCache } from "@mojis/internal-utils";
 import { vi } from "vitest";


### PR DESCRIPTION
fixes #88

I would like if we could have gotten rid of handler type generic, but that doesn't seem feasible.