### PR TITLE
feat: add persistence to source handler

### DIFF
--- a/.changeset/two-keys-repeat.md
+++ b/.changeset/two-keys-repeat.md
@@ -1,0 +1,6 @@
+---
+"@mojis/adapters": minor
+"@mojis/cli": minor
+---
+
+feat: add `persistence` function to source adapters

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -41,11 +41,13 @@
     "@mojis/schemas": "workspace:*",
     "arktype": "catalog:prod",
     "defu": "catalog:prod",
+    "fs-extra": "catalog:prod",
     "semver": "catalog:prod"
   },
   "devDependencies": {
     "@luxass/eslint-config": "catalog:dev",
     "@mojis/loomicode": "catalog:dev",
+    "@types/fs-extra": "catalog:dev",
     "@types/semver": "catalog:dev",
     "eslint": "catalog:dev",
     "tsup": "catalog:dev",

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -6,8 +6,6 @@ import type {
 import type { AnyVersionedSourceTransformer } from "../version-builder/types";
 import type {
   AnySourceAdapter,
-  FallbackFn,
-  PersistenceFn,
   PredicateFn,
   SourceAdapterBuilder,
 } from "./types";
@@ -82,8 +80,8 @@ export interface CreateBuilderOptions<
   TOutputSchema extends type.Any,
 > {
   type: TAdapterType;
-  outputSchema: TOutputSchema;
   transformerSchema: TTransformerSchema;
+  outputSchema: TOutputSchema;
 }
 
 export function createSourceAdapter<

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -23,8 +23,8 @@ function internalCreateSourceAdapterBuilder<
     _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
     _outputSchema: TOutputSchema;
     _transformerSchema: TTransformerSchema;
-    _persistence: PersistenceFn<TTransformerSchema["infer"], TOutputSchema["infer"]>;
     _fallback: FallbackFn<TOutputSchema["infer"]>;
+    _persistence: PersistenceFn<TTransformerSchema["infer"], TOutputSchema["infer"]>;
   }> {
   const _def: AnySourceAdapter = {
     adapterType: initDef.adapterType,
@@ -66,9 +66,14 @@ function internalCreateSourceAdapterBuilder<
   };
 }
 
-export interface CreateBuilderOptions<TAdapterType extends SourceAdapterType, TOutputSchema extends type.Any> {
+export interface CreateBuilderOptions<
+  TAdapterType extends SourceAdapterType,
+  TTransformerSchema extends type.Any,
+  TOutputSchema extends type.Any,
+> {
   type: TAdapterType;
-  outputSchema?: TOutputSchema;
+  outputSchema: TOutputSchema;
+  transformerSchema: TTransformerSchema;
 }
 
 export function createSourceAdapter<
@@ -76,14 +81,23 @@ export function createSourceAdapter<
   TTransformerSchema extends type.Any,
   TOutputSchema extends type.Any,
 >(
-  opts: CreateBuilderOptions<TAdapterType, TOutputSchema>,
+  opts: CreateBuilderOptions<
+    TAdapterType,
+    TTransformerSchema,
+    TOutputSchema
+  >,
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
     _transformerSchema: TTransformerSchema;
     _outputSchema: TOutputSchema;
-    _fallback: FallbackFn<TTransformerSchema["infer"]>;
-    _persistence: PersistenceFn<TTransformerSchema["infer"], TOutputSchema["infer"]>;
+    _fallback: FallbackFn<
+      TTransformerSchema["infer"]
+    >;
+    _persistence: PersistenceFn<
+      TTransformerSchema["infer"],
+      TOutputSchema["infer"]
+    >;
   }> {
   return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerSchema, TOutputSchema>({
     adapterType: opts.type,

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -1,6 +1,7 @@
 import type { type } from "arktype";
 import type {
   SourceAdapterType,
+  UnsetMarker,
 } from "../../global-types";
 import type { AnyVersionedSourceTransformer } from "../version-builder/types";
 import type {
@@ -23,8 +24,9 @@ function internalCreateSourceAdapterBuilder<
     _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
     _outputSchema: TOutputSchema;
     _transformerSchema: TTransformerSchema;
-    _fallback: FallbackFn<TOutputSchema["infer"]>;
-    _persistence: PersistenceFn<TTransformerSchema["infer"], TOutputSchema["infer"]>;
+    _fallback: UnsetMarker;
+    _persistence: UnsetMarker;
+    _persistenceOptions: UnsetMarker;
   }> {
   const _def: AnySourceAdapter = {
     adapterType: initDef.adapterType,
@@ -32,6 +34,8 @@ function internalCreateSourceAdapterBuilder<
     transformerSchema: initDef.transformerSchema,
     handlers: [],
     fallback: () => {},
+    persistence: undefined,
+    persistenceOptions: {} as any,
 
     // overload with properties passed in
     ...initDef,
@@ -58,6 +62,12 @@ function internalCreateSourceAdapterBuilder<
       return internalCreateSourceAdapterBuilder({
         ..._def,
         persistence: userFn,
+      }) as SourceAdapterBuilder<any>;
+    },
+    persistenceOptions(userOptions) {
+      return internalCreateSourceAdapterBuilder({
+        ..._def,
+        persistenceOptions: userOptions,
       }) as SourceAdapterBuilder<any>;
     },
     build() {
@@ -91,16 +101,13 @@ export function createSourceAdapter<
     _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
     _transformerSchema: TTransformerSchema;
     _outputSchema: TOutputSchema;
-    _fallback: FallbackFn<
-      TTransformerSchema["infer"]
-    >;
-    _persistence: PersistenceFn<
-      TTransformerSchema["infer"],
-      TOutputSchema["infer"]
-    >;
+    _fallback: UnsetMarker;
+    _persistence: UnsetMarker;
+    _persistenceOptions: UnsetMarker;
   }> {
   return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerSchema, TOutputSchema>({
     adapterType: opts.type,
+    transformerSchema: opts.transformerSchema,
     outputSchema: opts.outputSchema,
   });
 }

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -17,8 +17,8 @@ export interface SourceAdapterBuilder<
 > {
   onVersion: <
     TPredicate extends PredicateFn,
-    TBuilderParams extends Omit<AnyVersionedSourceTransformerParams, "_outputSchema"> & {
-      _outputSchema: TParams["_outputSchema"] extends type.Any ? TParams["_outputSchema"]["infer"] : any;
+    TBuilderParams extends Omit<AnyVersionedSourceTransformerParams, "_transformerSchema"> & {
+      _outputSchema: TParams["_transformerSchema"] extends type.Any ? TParams["_transformerSchema"]["infer"] : any;
     },
     TBuilder extends VersionedSourceTransformerBuilder<TBuilderParams>,
     THandler extends AnyVersionedSourceTransformer,
@@ -28,35 +28,96 @@ export interface SourceAdapterBuilder<
   ) => SourceAdapterBuilder<{
     _adapterType: TParams["_adapterType"];
     _outputSchema: TParams["_outputSchema"];
+    _transformerSchema: TParams["_transformerSchema"];
     _handlers: MergeTuple<
       [[TPredicate, THandler]],
       TParams["_handlers"]
     >;
     _fallback: TParams["_fallback"];
+    _persistence: TParams["_persistence"];
   }>;
 
-  fallback: <TOut extends TParams["_outputSchema"] extends type.Any ? TParams["_outputSchema"]["infer"] : any>(
+  fallback: <TOut extends TParams["_transformerSchema"] extends type.Any ? TParams["_transformerSchema"]["infer"] : any>(
+    fn: FallbackFn<TOut>
+  ) => SourceAdapterBuilder<{
+    _fallback: TOut;
+    _handlers: TParams["_handlers"];
+    _transformerSchema: TParams["_transformerSchema"];
+    _outputSchema: TParams["_outputSchema"];
+    _adapterType: TParams["_adapterType"];
+    _persistence: TParams["_persistence"];
+  }>;
+
+  persistence: <TOut extends TParams["_outputSchema"] extends type.Any ? TParams["_outputSchema"]["infer"] : any>(
     fn: FallbackFn<TOut>
   ) => SourceAdapterBuilder<{
     _fallback: TOut;
     _handlers: TParams["_handlers"];
     _outputSchema: TParams["_outputSchema"];
+    _transformerSchema: TParams["_transformerSchema"];
     _adapterType: TParams["_adapterType"];
+    _persistence: TOut;
   }>;
 
   build: () => SourceAdapter<{
     fallback: TParams["_fallback"];
     handlers: TParams["_handlers"];
     outputSchema: TParams["_outputSchema"];
+    transformerSchema: TParams["_transformerSchema"];
     adapterType: TParams["_adapterType"];
   }>;
 }
 
+export interface PersistenceOptions {
+  /**
+   * Whether to force overwrite of existing files.
+   * @default false
+   */
+  force?: boolean;
+
+  /**
+   * Version information for the emoji data.
+   */
+  version: {
+    /**
+     * The emoji version.
+     */
+    emoji_version: string;
+
+    /**
+     * The unicode version.
+     */
+    unicode_version: string;
+  };
+
+  /**
+   * Whether to pretty-print the output JSON.
+   * @default false
+   */
+  pretty?: boolean;
+
+  /**
+   * The file extension to use for the output files.
+   * @default "json"
+   */
+  fileExtension?: string;
+
+  /**
+   * The encoding to use when writing files.
+   * @default "utf-8"
+   */
+  encoding?: BufferEncoding;
+}
+
+export type PersistenceFn<TIn, TOut> = (data: TIn, options: PersistenceOptions) => Promise<TOut>;
+
 export interface AnySourceAdapterParams {
   _adapterType: SourceAdapterType;
-  _outputSchema?: type.Any;
+  _outputSchema: type.Any;
+  _transformerSchema: type.Any;
   _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
-  _fallback?: any;
+  _fallback: any;
+  _persistence: any;
 }
 
 export type PredicateFn = (version: string) => boolean;
@@ -64,8 +125,10 @@ export type PredicateFn = (version: string) => boolean;
 export interface AnyBuiltSourceAdapterParams {
   adapterType: SourceAdapterType;
   handlers: [PredicateFn, AnyVersionedSourceTransformer][];
-  outputSchema?: type.Any;
+  transformerSchema: type.Any;
+  outputSchema: type.Any;
   fallback?: FallbackFn<any>;
+  persistence?: PersistenceFn<any, any>;
 }
 
 export type FallbackFn<TOut> = () => TOut;
@@ -73,8 +136,17 @@ export type FallbackFn<TOut> = () => TOut;
 export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
   adapterType: TParams["adapterType"];
   handlers: TParams["handlers"];
-  outputSchema?: TParams["outputSchema"];
+  transformerSchema: TParams["transformerSchema"];
+  outputSchema: TParams["outputSchema"];
   fallback?: FallbackFn<
+    TParams["transformerSchema"] extends type.Any
+      ? TParams["transformerSchema"]["infer"]
+      : any
+  >;
+  persistence?: PersistenceFn<
+    TParams["transformerSchema"] extends type.Any
+      ? TParams["transformerSchema"]["infer"]
+      : any,
     TParams["outputSchema"] extends type.Any
       ? TParams["outputSchema"]["infer"]
       : any

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -20,7 +20,7 @@ export interface SourceAdapterBuilder<
 > {
   onVersion: <
     TPredicate extends PredicateFn,
-    TBuilderParams extends Omit<AnyVersionedSourceTransformerParams, "_transformerSchema"> & {
+    TBuilderParams extends Omit<AnyVersionedSourceTransformerParams, "_outputSchema"> & {
       _outputSchema: TParams["_transformerSchema"] extends type.Any ? TParams["_transformerSchema"]["infer"] : any;
     },
     TBuilder extends VersionedSourceTransformerBuilder<TBuilderParams>,
@@ -205,11 +205,11 @@ export type PredicateFn = (version: string) => boolean;
 export interface AnyBuiltSourceAdapterParams {
   adapterType: SourceAdapterType;
   handlers: [PredicateFn, AnyVersionedSourceTransformer][];
-  transformerSchema: type.Any;
-  outputSchema: type.Any;
+  transformerSchema?: type.Any;
+  outputSchema?: type.Any;
   fallback?: FallbackFn<any>;
   persistence?: PersistenceFn<any, any>;
-  persistenceOptions: Omit<PersistenceOptions, "version">;
+  persistenceOptions?: Omit<PersistenceOptions, "version">;
 }
 
 export type FallbackFn<TOut> = () => TOut;
@@ -232,7 +232,7 @@ export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
       ? TParams["outputSchema"]["infer"]
       : any
   >;
-  persistenceOptions: TParams["persistenceOptions"];
+  persistenceOptions?: TParams["persistenceOptions"];
 }
 
 export type AnySourceAdapter = SourceAdapter<any>;

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -1,6 +1,7 @@
 import type { EmojiGroup, GroupedEmojiMetadata } from "@mojis/schemas/emojis";
+import { join } from "node:path";
 import { extractEmojiVersion, extractUnicodeVersion, isBefore } from "@mojis/internal-utils";
-import { EMOJI_GROUPS_SCHEMA, GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA } from "@mojis/schemas/emojis";
+import { EMOJI_GROUPS_SCHEMA, GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA, GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA } from "@mojis/schemas/emojis";
 import { type } from "arktype";
 import { createSourceAdapter } from "../../builders/source-builder/builder";
 
@@ -22,9 +23,13 @@ const DISALLOWED_EMOJI_VERSIONS = ["1.0", "2.0", "3.0"];
 
 const builder = createSourceAdapter({
   type: "metadata",
-  outputSchema: type({
+  transformerSchema: type({
     groups: EMOJI_GROUPS_SCHEMA,
     emojis: GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA,
+  }),
+  outputSchema: type({
+    groups: EMOJI_GROUPS_SCHEMA,
+    emojis: GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA,
   }),
 });
 
@@ -153,7 +158,18 @@ export const handler = builder
       groups: [],
     };
   })
-  // .onError((err) => {
-  //   console.error(err);
-  // })
+  .persistence((data, opts) => {
+    return [
+      {
+        filePath: join(opts.basePath, "groups.json"),
+        data: data.groups,
+        type: "json" as const,
+      },
+      ...Object.entries(data.emojis).map(([group, metadata]) => ({
+        filePath: join(opts.basePath, "metadata", `${group}.json`),
+        data: metadata,
+        type: "json" as const,
+      })),
+    ];
+  })
   .build();

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,7 +1,8 @@
 export type { SourceAdapterType } from "./global-types";
-
 export * as compositeHandlers from "./handlers/composite";
+
 export * as sourceHandlers from "./handlers/source";
 
 export { runCompositeHandler } from "./runners/composite-runner";
 export { runSourceAdapter } from "./runners/source-runner";
+export { buildContext } from "./utils";

--- a/packages/adapters/src/runners/source-runner.ts
+++ b/packages/adapters/src/runners/source-runner.ts
@@ -1,11 +1,19 @@
 import type { Cache, CacheOptions } from "@mojis/internal-utils";
 import type { AnySourceAdapter, InferHandlerOutput } from "../builders/source-builder/types";
 import type { AdapterContext } from "../global-types";
+import path, { join } from "node:path";
 import { arktypeParse } from "@mojis/internal-utils";
+import fs from "fs-extra";
 import { AdapterError } from "../errors";
 import { runVersionedSourceTransformer } from "./version-runner";
 
-export interface RunSourceAdapterOverrides {
+export interface RunSourceAdapterOptions {
+  /**
+   * Whether to write the output to disk or not.
+   * @default true
+   */
+  write?: boolean;
+
   cacheKey?: string;
   cacheOptions?: CacheOptions;
   cache?: Cache<string>;
@@ -13,11 +21,12 @@ export interface RunSourceAdapterOverrides {
 
 export async function runSourceAdapter<
   THandler extends AnySourceAdapter,
+  TOptions extends RunSourceAdapterOptions = RunSourceAdapterOptions,
 >(
   handler: THandler,
   ctx: AdapterContext,
-  __overrides?: RunSourceAdapterOverrides,
-): Promise<InferHandlerOutput<THandler>> {
+  options?: TOptions,
+): Promise<TOptions["write"] extends false ? InferHandlerOutput<THandler> : void> {
   const promises = [];
 
   let output = (typeof handler.fallback == "function" && handler.fallback != null) ? handler.fallback() : undefined;
@@ -28,7 +37,11 @@ export async function runSourceAdapter<
       continue;
     }
 
-    promises.push(runVersionedSourceTransformer(ctx, sourceTransformer, handler.adapterType, __overrides));
+    promises.push(runVersionedSourceTransformer(ctx, sourceTransformer, handler.adapterType, {
+      cacheOptions: options?.cacheOptions,
+      cacheKey: options?.cacheKey,
+      cache: options?.cache,
+    }));
   }
 
   const result = await Promise.all(promises);
@@ -38,15 +51,71 @@ export async function runSourceAdapter<
     output = result[0];
   }
 
-  if (handler.outputSchema == null) {
-    return output as InferHandlerOutput<THandler>;
+  if (handler.transformerSchema == null) {
+    throw new Error(`no transformer schema defined for adapter ${handler.adapterType}`);
   }
 
-  const validationResult = arktypeParse(output, handler.outputSchema);
+  const validationResult = arktypeParse(output, handler.transformerSchema);
 
   if (!validationResult.success) {
-    throw new AdapterError(`Invalid output for handler: ${handler.adapterType}`);
+    throw new AdapterError(`invalid output for handler: ${handler.adapterType}`);
   }
 
-  return validationResult.data as InferHandlerOutput<THandler>;
+  if (!options?.write) {
+    return validationResult.data as InferHandlerOutput<THandler>;
+  }
+
+  if (handler.persistence == null) {
+    throw new Error(`no persistence function defined for adapter ${handler.adapterType}`);
+  }
+
+  const basePath = join("./data", `v${ctx.emoji_version}`);
+
+  const fileOperations = await handler.persistence(validationResult.data, {
+    basePath,
+    force: ctx.force,
+    pretty: handler.persistenceOptions.pretty,
+    version: {
+      emoji_version: ctx.emoji_version,
+      unicode_version: ctx.unicode_version,
+    },
+  });
+
+  await Promise.all(
+    fileOperations.map(async (operation) => {
+      const { filePath, data, type, options: fileOptions = {} } = operation;
+      const {
+        encoding = "utf-8",
+        pretty = handler.persistenceOptions.pretty ?? false,
+        force = ctx.force ?? false,
+      } = fileOptions;
+
+      // Create directory if it doesn't exist
+      const dir = path.dirname(filePath);
+      await fs.ensureDir(dir);
+
+      // Skip if file exists and force is false
+      if (!force && await fs.pathExists(filePath)) {
+        console.warn(`File exists and force is false, skipping: ${filePath}`);
+        return;
+      }
+
+      // Write the file
+      if (type === "json") {
+        await fs.writeFile(
+          filePath,
+          pretty ? JSON.stringify(data, null, 2) : JSON.stringify(data),
+          { encoding },
+        );
+      } else {
+        await fs.writeFile(
+          filePath,
+          String(data),
+          { encoding },
+        );
+      }
+    }),
+  );
+
+  return undefined as unknown as TOptions["write"] extends false ? InferHandlerOutput<THandler> : void;
 }

--- a/packages/adapters/src/runners/source-runner.ts
+++ b/packages/adapters/src/runners/source-runner.ts
@@ -29,6 +29,8 @@ export async function runSourceAdapter<
 ): Promise<TOptions["write"] extends false ? InferHandlerOutput<THandler> : void> {
   const promises = [];
 
+  const shouldWrite = options?.write ?? true;
+
   let output = (typeof handler.fallback == "function" && handler.fallback != null) ? handler.fallback() : undefined;
 
   for (const [predicate, sourceTransformer] of handler.handlers) {
@@ -61,7 +63,7 @@ export async function runSourceAdapter<
     throw new AdapterError(`invalid output for handler: ${handler.adapterType}`);
   }
 
-  if (!options?.write) {
+  if (!shouldWrite) {
     return validationResult.data as InferHandlerOutput<THandler>;
   }
 
@@ -90,17 +92,17 @@ export async function runSourceAdapter<
         force = ctx.force ?? false,
       } = fileOptions;
 
-      // Create directory if it doesn't exist
+      // create directory if it doesn't exist
       const dir = path.dirname(filePath);
       await fs.ensureDir(dir);
 
-      // Skip if file exists and force is false
+      // skip if file exists and force is false
       if (!force && await fs.pathExists(filePath)) {
         console.warn(`File exists and force is false, skipping: ${filePath}`);
         return;
       }
 
-      // Write the file
+      // write the file
       if (type === "json") {
         await fs.writeFile(
           filePath,

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -122,7 +122,7 @@ export async function getHandlerUrls<TContext extends AdapterContext>(
  */
 export function buildContext<TContext extends AdapterContext, TExtraContext extends Record<string, unknown>>(
   ctx: TContext,
-  extraContext: TExtraContext,
+  extraContext: TExtraContext = {} as TExtraContext,
 ): TContext & TExtraContext {
   return Object.assign({}, ctx, extraContext);
 }

--- a/packages/adapters/test/builders/adapter-handler.test-d.ts
+++ b/packages/adapters/test/builders/adapter-handler.test-d.ts
@@ -6,22 +6,30 @@ import { describe, expectTypeOf, it } from "vitest";
 
 describe("InferHandlerOutput", () => {
   it("should infer the output of an adapter handler", () => {
-    type Result = InferHandlerOutput<CreateAnySourceAdapter<"test", {
-      handlers: [
-        CreateVersionedSourceTransformer<{ output: string }>,
-      ];
-    }>>;
+    type Result = InferHandlerOutput<CreateAnySourceAdapter<
+      // @ts-expect-error `test` is not a valid adapter type
+      "test",
+      {
+        handlers: [
+          CreateVersionedSourceTransformer<{ output: string }>,
+        ];
+      }
+    >>;
 
     expectTypeOf<Result>().toEqualTypeOf<string>();
   });
 
   it("should infer the output of an adapter handler with multiple handlers", () => {
-    type Result = InferHandlerOutput<CreateAnySourceAdapter<"test", {
-      fallback: () => string;
-      handlers: [
-        CreateVersionedSourceTransformer<{ output: string }>,
-      ];
-    }>>;
+    type Result = InferHandlerOutput<CreateAnySourceAdapter<
+      // @ts-expect-error `test` is not a valid adapter type
+      "test",
+      {
+        handlers: [
+          CreateVersionedSourceTransformer<{ output: string }>,
+        ];
+        fallback: () => string;
+      }
+    >>;
 
     expectTypeOf<Result>().toEqualTypeOf<string>();
   });

--- a/packages/adapters/test/builders/adapter-handler.test.ts
+++ b/packages/adapters/test/builders/adapter-handler.test.ts
@@ -3,23 +3,40 @@ import { type } from "arktype";
 import { describe, expect, it } from "vitest";
 import { createSourceAdapter } from "../../src/builders/source-builder/builder";
 
+const dummySchema = type({
+  name: "string",
+  age: "number",
+});
+
 describe("adapter handler builder", () => {
   const emptyContext = {} as AdapterContext;
 
   it("creates with type", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder.build();
     expect(handler.adapterType).toBe("metadata");
   });
 
   it("creates with empty handlers", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder.build();
     expect(handler.handlers).toHaveLength(0);
   });
 
   it("adds version handler", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder
       .onVersion(
         (version) => version === "15.0",
@@ -35,7 +52,11 @@ describe("adapter handler builder", () => {
   });
 
   it("adds multiple version handlers", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder
       .onVersion(
         (version) => version === "15.0",
@@ -59,7 +80,11 @@ describe("adapter handler builder", () => {
   });
 
   it("maintains handler order", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder
       .onVersion(
         (version) => version === "15.0",
@@ -87,7 +112,11 @@ describe("adapter handler builder", () => {
   });
 
   it("preserves adapter type across chain", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder
       .onVersion(
         (version) => version === "15.0",
@@ -109,7 +138,11 @@ describe("adapter handler builder", () => {
   });
 
   it("allows chaining multiple onVersion calls", () => {
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: dummySchema,
+    });
     const handler = builder
       .onVersion(
         (version) => version === "15.0",
@@ -142,7 +175,14 @@ describe("adapter handler builder", () => {
 
   it("allows setting fallback data", () => {
     const fallbackData = { defaultValue: true };
-    const builder = createSourceAdapter({ type: "metadata" });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      outputSchema: dummySchema,
+      transformerSchema: type({
+        defaultValue: "boolean",
+      }),
+    });
+
     const handler = builder
       .fallback(() => fallbackData)
       .build();
@@ -155,9 +195,11 @@ describe("adapter handler builder", () => {
     const testSchema = type({
       name: "string",
     });
+
     const builder = createSourceAdapter({
       type: "metadata",
       outputSchema: testSchema,
+      transformerSchema: testSchema,
     });
     const handler = builder.build();
 

--- a/packages/adapters/test/builders/composite-handler.test-d.ts
+++ b/packages/adapters/test/builders/composite-handler.test-d.ts
@@ -33,20 +33,28 @@ describe("MergeSources", () => {
     };
 
     type Source2 = [
-      CreateAnySourceAdapter<"version", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: number;
-          }>,
-        ];
-      }>,
-      CreateAnySourceAdapter<"world", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string;
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `version` is not a valid adapterType
+        "version",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: number;
+            }>,
+          ];
+        }
+      >,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `world` is not a valid adapterType
+        "world",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string;
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -63,20 +71,28 @@ describe("MergeSources", () => {
     type Source1 = {};
 
     type Source2 = [
-      CreateAnySourceAdapter<"version", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string;
-          }>,
-        ];
-      }>,
-      CreateAnySourceAdapter<"hello", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: number;
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `version` is not a valid adapterType
+        "version",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string;
+            }>,
+          ];
+        }
+      >,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `hello` is not a valid adapterType
+        "hello",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: number;
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -95,20 +111,28 @@ describe("MergeSources", () => {
     };
 
     type Source2 = [
-      CreateAnySourceAdapter<"array", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string[];
-          }>,
-        ];
-      }>,
-      CreateAnySourceAdapter<"object", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: { key: string };
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `array` is not a valid adapterType
+        "array",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string[];
+            }>,
+          ];
+        }
+      >,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `object` is not a valid adapterType
+        "object",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: { key: string };
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -129,13 +153,17 @@ describe("MergeSources", () => {
     };
 
     type Source2 = [
-      CreateAnySourceAdapter<"version", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string;
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `version` is not a valid adapterType
+        "version",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string;
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -152,18 +180,22 @@ describe("MergeSources", () => {
     };
 
     type Source2 = [
-      CreateAnySourceAdapter<"complex", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: {
-              nested: {
-                value: number;
-                array: string[];
+      CreateAnySourceAdapter<
+        // @ts-expect-error `complex` is not a valid adapterType
+        "complex",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: {
+                nested: {
+                  value: number;
+                  array: string[];
+                };
               };
-            };
-          }>,
-        ];
-      }>,
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -187,13 +219,17 @@ describe("MergeSources", () => {
     };
 
     type Source2 = [
-      CreateAnySourceAdapter<"dynamic", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string;
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `dynamic` is not a valid adapterType
+        "dynamic",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string;
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -210,20 +246,28 @@ describe("MergeSources", () => {
     type Source1 = {};
 
     type Source2 = [
-      CreateAnySourceAdapter<"same", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: string;
-          }>,
-        ];
-      }>,
-      CreateAnySourceAdapter<"same", {
-        handlers: [
-          CreateVersionedSourceTransformer<{
-            output: number;
-          }>,
-        ];
-      }>,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `same` is not a valid adapterType
+        "same",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: string;
+            }>,
+          ];
+        }
+      >,
+      CreateAnySourceAdapter<
+        // @ts-expect-error `same` is not a valid adapterType
+        "same",
+        {
+          handlers: [
+            CreateVersionedSourceTransformer<{
+              output: number;
+            }>,
+          ];
+        }
+      >,
     ];
 
     type Result = MergeSources<Source1, Source2>;
@@ -252,13 +296,17 @@ describe("MergeSources", () => {
       type Source1 = UnsetMarker;
 
       type Source2 = [
-        CreateAnySourceAdapter<"version", {
-          handlers: [
-            CreateVersionedSourceTransformer<{
-              output: string;
-            }>,
-          ];
-        }>,
+        CreateAnySourceAdapter<
+          // @ts-expect-error `version` is not a valid adapterType
+          "version",
+          {
+            handlers: [
+              CreateVersionedSourceTransformer<{
+                output: string;
+              }>,
+            ];
+          }
+        >,
       ];
 
       type Result = MergeSources<Source1, Source2>;

--- a/packages/adapters/test/runners/composite-runner.test.ts
+++ b/packages/adapters/test/runners/composite-runner.test.ts
@@ -92,6 +92,9 @@ describe("run composite handler", () => {
           outputSchema: type({
             version: "string",
           }),
+          transformerSchema: type({
+            version: "string",
+          }),
         }),
       ])
       .output(() => {
@@ -149,6 +152,9 @@ describe("run composite handler", () => {
           outputSchema: type({
             version: "string",
           }),
+          transformerSchema: type({
+            version: "string",
+          }),
         }),
       ])
       .output(() => {
@@ -185,7 +191,11 @@ describe("run composite handler", () => {
         }],
       ]);
 
-      const nameHandler = createVersionedSourceTransformerBuilder()
+      const outputSchema = type({
+        name: "string",
+      });
+
+      const nameHandler = createVersionedSourceTransformerBuilder<typeof outputSchema["infer"]>()
         .urls(() => "https://mojis.dev/random-name")
         .parser((_, data) => data)
         .transform((_, data) => data)
@@ -203,12 +213,10 @@ describe("run composite handler", () => {
         .adapterSources([
           createFakeSourceAdapter({
             adapterType: "metadata",
+            transformerSchema: outputSchema,
             handlers: [
               [() => true, nameHandler],
             ],
-            outputSchema: type({
-              name: "string",
-            }),
           }),
         ])
         .transform((_, data) => {
@@ -218,6 +226,7 @@ describe("run composite handler", () => {
             },
             amount: 2,
           });
+          expectTypeOf(data.metadata).not.toBeAny();
 
           let val = "";
           for (let i = 0; i < data.amount; i++) {

--- a/packages/adapters/test/runners/source-runner.test.ts
+++ b/packages/adapters/test/runners/source-runner.test.ts
@@ -26,8 +26,7 @@ describe("runSourceAdapter", () => {
 
     const handler = createFakeSourceAdapter({
       adapterType: "metadata",
-      handlers: [
-      ],
+      handlers: [],
     });
 
     const result = await runSourceAdapter(handler, mockContext);
@@ -119,6 +118,9 @@ describe("runSourceAdapter", () => {
         [(version: string) => version === "15.0", mockHandler2],
         [(version: string) => version === "14.0", mockHandler3],
       ],
+      transformerSchema: type({
+        processedBy: "string",
+      }),
     });
 
     const result = await runSourceAdapter(handler, mockContext);

--- a/packages/cli/src/cmd/generate.ts
+++ b/packages/cli/src/cmd/generate.ts
@@ -154,6 +154,13 @@ export async function buildEmojiGenerateRequest(
       "utf-8",
     );
 
+    const groupData = await Promise.all(Object.entries(emojis).map(async ([group, metadata]) => {
+      return {
+        group,
+        data: metadata,
+      };
+    }));
+
     await Promise.all(Object.entries(emojis).map(async ([group, metadata]) => fs.writeFile(
       join(baseDir, "metadata", `${group}.json`),
       JSON.stringify(metadata, null, 2),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       defu:
         specifier: catalog:prod
         version: 6.1.4
+      fs-extra:
+        specifier: catalog:prod
+        version: 11.3.0
       semver:
         specifier: catalog:prod
         version: 7.7.1
@@ -143,6 +146,9 @@ importers:
       '@mojis/loomicode':
         specifier: catalog:dev
         version: 0.2.0-beta.7
+      '@types/fs-extra':
+        specifier: catalog:dev
+        version: 11.0.4
       '@types/semver':
         specifier: catalog:dev
         version: 7.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,24 @@ catalogs:
     vitest: ^3.0.9
     vitest-testdirs: ^3.0.1
     tsx: ^4.19.3
+  conflicts_prod_:
+    fs-extra: ""
+  conflicts_prod_11_3_0:
+    fs-extra: 11.3.0
+  conflicts_prod_c:
+    fs-extra: c
+  conflicts_prod_ca:
+    fs-extra: ca
+  conflicts_prod_cat:
+    fs-extra: cat
+  conflicts_prod_cata:
+    fs-extra: cata
+  conflicts_prod_catal:
+    fs-extra: catal
+  conflicts_prod_catalo:
+    fs-extra: catalo
+  conflicts_prod_catalog:
+    fs-extra: catalog
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
This PR implements the `persistence` function to source adapters. This will replace the need to do file writing in the generate cli command.

Over time, this will also make it easier to setup some kind of automation to detect when to add a new json schema or when we need to update a json schema.


TODO:
- [ ] Normalize Schema Names (bit confusing that source transformers has output schema, but source adapter has both output schema and transformer schema)
- [ ] Fix Type Inferrence for Composite
