### PR TITLE
refactor: rename versioned source transformer to source transformer

### DIFF
--- a/.changeset/thirty-moments-march.md
+++ b/.changeset/thirty-moments-march.md
@@ -1,0 +1,5 @@
+---
+"@mojis/adapters": patch
+---
+
+rename versioned source transformer to source transformer

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -2,20 +2,20 @@ import type { type } from "arktype";
 import type {
   SourceAdapterType,
 } from "../../global-types";
-import type { AnyVersionedSourceTransformer } from "../version-builder/types";
+import type { AnySourceTransformer } from "../version-builder/types";
 import type {
   AnySourceAdapter,
   FallbackFn,
   PredicateFn,
   SourceAdapterBuilder,
 } from "./types";
-import { createVersionedSourceTransformerBuilder } from "../version-builder/builder";
+import { createSourceTransformerBuilder } from "../version-builder/builder";
 
 function internalCreateSourceAdapterBuilder<TAdapterType extends SourceAdapterType, TOutputSchema extends type.Any>(
   initDef: Partial<AnySourceAdapter> = {},
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
-    _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
+    _handlers: [PredicateFn, AnySourceTransformer][];
     _outputSchema: TOutputSchema;
     _fallback: FallbackFn<TOutputSchema["infer"]>;
   }> {
@@ -31,7 +31,7 @@ function internalCreateSourceAdapterBuilder<TAdapterType extends SourceAdapterTy
 
   return {
     onVersion(userPredicate, userBuilder) {
-      const sourceTransformer = userBuilder(createVersionedSourceTransformerBuilder<TOutputSchema["infer"]>() as any);
+      const sourceTransformer = userBuilder(createSourceTransformerBuilder<TOutputSchema["infer"]>() as any);
       return internalCreateSourceAdapterBuilder({
         ..._def,
         handlers: [
@@ -61,7 +61,7 @@ export function createSourceAdapter<TAdapterType extends SourceAdapterType, TOut
   opts: CreateBuilderOptions<TAdapterType, TOutputSchema>,
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
-    _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
+    _handlers: [PredicateFn, AnySourceTransformer][];
     _outputSchema: TOutputSchema;
   }> {
   return internalCreateSourceAdapterBuilder<TAdapterType, TOutputSchema>({

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -30,7 +30,7 @@ function internalCreateSourceAdapterBuilder<TAdapterType extends SourceAdapterTy
   };
 
   return {
-    onVersion(userPredicate, userBuilder) {
+    withTransform(userPredicate, userBuilder) {
       const sourceTransformer = userBuilder(createSourceTransformerBuilder<TOutputSchema["infer"]>() as any);
       return internalCreateSourceAdapterBuilder({
         ..._def,

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -15,7 +15,7 @@ export type InferHandlerOutput<TSourceAdapter extends AnySourceAdapter> =
 export interface SourceAdapterBuilder<
   TParams extends AnySourceAdapterParams,
 > {
-  onVersion: <
+  withTransform: <
     TPredicate extends PredicateFn,
     TBuilderParams extends Omit<AnySourceTransformerParams, "_outputSchema"> & {
       _outputSchema: TParams["_outputSchema"] extends type.Any ? TParams["_outputSchema"]["infer"] : any;

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -3,11 +3,11 @@ import type {
   MergeTuple,
   SourceAdapterType,
 } from "../../global-types";
-import type { AnyVersionedSourceTransformer, AnyVersionedSourceTransformerParams, VersionedSourceTransformerBuilder } from "../version-builder/types";
+import type { AnySourceTransformer, AnySourceTransformerParams, SourceTransformerBuilder } from "../version-builder/types";
 
 export type InferHandlerOutput<TSourceAdapter extends AnySourceAdapter> =
   TSourceAdapter extends { handlers: Array<[any, infer TSourceTransformer]> }
-    ? TSourceTransformer extends AnyVersionedSourceTransformer
+    ? TSourceTransformer extends AnySourceTransformer
       ? TSourceTransformer["output"]
       : never
     : never;
@@ -17,11 +17,11 @@ export interface SourceAdapterBuilder<
 > {
   onVersion: <
     TPredicate extends PredicateFn,
-    TBuilderParams extends Omit<AnyVersionedSourceTransformerParams, "_outputSchema"> & {
+    TBuilderParams extends Omit<AnySourceTransformerParams, "_outputSchema"> & {
       _outputSchema: TParams["_outputSchema"] extends type.Any ? TParams["_outputSchema"]["infer"] : any;
     },
-    TBuilder extends VersionedSourceTransformerBuilder<TBuilderParams>,
-    THandler extends AnyVersionedSourceTransformer,
+    TBuilder extends SourceTransformerBuilder<TBuilderParams>,
+    THandler extends AnySourceTransformer,
   >(
     predicate: TPredicate,
     builder: (builder: TBuilder) => THandler,
@@ -55,7 +55,7 @@ export interface SourceAdapterBuilder<
 export interface AnySourceAdapterParams {
   _adapterType: SourceAdapterType;
   _outputSchema?: type.Any;
-  _handlers: [PredicateFn, AnyVersionedSourceTransformer][];
+  _handlers: [PredicateFn, AnySourceTransformer][];
   _fallback?: any;
 }
 
@@ -63,7 +63,7 @@ export type PredicateFn = (version: string) => boolean;
 
 export interface AnyBuiltSourceAdapterParams {
   adapterType: SourceAdapterType;
-  handlers: [PredicateFn, AnyVersionedSourceTransformer][];
+  handlers: [PredicateFn, AnySourceTransformer][];
   outputSchema?: type.Any;
   fallback?: FallbackFn<any>;
 }

--- a/packages/adapters/src/builders/version-builder/builder.ts
+++ b/packages/adapters/src/builders/version-builder/builder.ts
@@ -2,13 +2,13 @@ import type {
   AdapterContext,
   UnsetMarker,
 } from "../../global-types";
-import type { AnyVersionedSourceTransformer, VersionedSourceTransformerBuilder } from "./types";
+import type { AnySourceTransformer, SourceTransformerBuilder } from "./types";
 
-function internalCreateVersionedSourceTransformerBuilder<
+function internalCreateSourceTransformerBuilder<
   TOutputSchema,
 >(
-  initDef: Partial<AnyVersionedSourceTransformer> = {},
-): VersionedSourceTransformerBuilder<{
+  initDef: Partial<AnySourceTransformer> = {},
+): SourceTransformerBuilder<{
     _context: AdapterContext;
     _urls: UnsetMarker;
     _aggregate: {
@@ -33,59 +33,59 @@ function internalCreateVersionedSourceTransformerBuilder<
     _validation: UnsetMarker;
     _outputSchema: TOutputSchema;
   }> {
-  const _def: Partial<AnyVersionedSourceTransformer> = {
+  const _def: Partial<AnySourceTransformer> = {
     outputSchema: initDef.outputSchema,
     ...initDef,
   };
 
   return {
     urls(userUrls) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         urls: userUrls,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     parser(userParser, userParserOptions) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         parser: userParser,
         parserOptions: userParserOptions,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     transform(userTransform) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         transform: userTransform,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     aggregate(userAggregate) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         aggregate: userAggregate,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     cacheOptions(userCacheOptions) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         cacheOptions: userCacheOptions,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     fetchOptions(userFetchOptions) {
-      return internalCreateVersionedSourceTransformerBuilder({
+      return internalCreateSourceTransformerBuilder({
         ..._def,
         fetchOptions: userFetchOptions,
-      }) as VersionedSourceTransformerBuilder<any>;
+      }) as SourceTransformerBuilder<any>;
     },
     output(userOutput) {
       return {
         ..._def,
         output: userOutput,
-      } as AnyVersionedSourceTransformer;
+      } as AnySourceTransformer;
     },
   };
 }
 
-export function createVersionedSourceTransformerBuilder<TOutputSchema>(): VersionedSourceTransformerBuilder<{
+export function createSourceTransformerBuilder<TOutputSchema>(): SourceTransformerBuilder<{
   _aggregate: {
     in: UnsetMarker;
     out: UnsetMarker;
@@ -110,5 +110,5 @@ export function createVersionedSourceTransformerBuilder<TOutputSchema>(): Versio
   _validation: UnsetMarker;
   _outputSchema: TOutputSchema;
 }> {
-  return internalCreateVersionedSourceTransformerBuilder<TOutputSchema>();
+  return internalCreateSourceTransformerBuilder<TOutputSchema>();
 }

--- a/packages/adapters/src/builders/version-builder/types.ts
+++ b/packages/adapters/src/builders/version-builder/types.ts
@@ -25,7 +25,7 @@ export type InferParseOutput<
     ? TOutput
     : never;
 
-export interface AnyVersionedSourceTransformerParams {
+export interface AnySourceTransformerParams {
   _context: AdapterContext;
   _urls: any;
   _aggregate: {
@@ -81,12 +81,12 @@ export type WrapContextFn<
   TReturn,
 > = ((ctx: TContext & TExtraContext) => TReturn) | TReturn;
 
-export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedSourceTransformerParams> {
+export interface SourceTransformerBuilder<TParams extends AnySourceTransformerParams> {
   urls: <TUrls extends PossibleUrls>(
     urls: TParams["_urls"] extends UnsetMarker
       ? UrlFn<TUrls>
       : ErrorMessage<"urls is already set">,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _urls: TUrls;
     _aggregate: TParams["_aggregate"];
@@ -112,7 +112,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
         GetParseOptionsFromParser<TParser>
       >
       : never,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _urls: TParams["_urls"];
     _aggregate: TParams["_aggregate"];
@@ -138,7 +138,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
     transform: TParams["_transform"]["in"] extends UnsetMarker
       ? TransformFn<AdapterContext, TIn, TOut>
       : ErrorMessage<"transform is already set">,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _urls: TParams["_urls"];
     _aggregate: TParams["_aggregate"];
@@ -161,7 +161,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
     aggregate: TParams["_aggregate"]["in"] extends UnsetMarker
       ? AggregateFn<AdapterContext, TIn, TOut>
       : ErrorMessage<"aggregate is already set">,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _outputSchema: TParams["_outputSchema"];
     _aggregate: {
@@ -183,7 +183,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
     cacheOptions: TParams["_options"]["cacheOptions"] extends UnsetMarker
       ? TOptions
       : ErrorMessage<"cacheOptions is already set">,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _outputSchema: TParams["_outputSchema"];
     _urls: TParams["_urls"];
@@ -203,7 +203,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
     fetchOptions: TParams["_options"]["fetchOptions"] extends UnsetMarker
       ? TOptions
       : ErrorMessage<"fetchOptions is already set">,
-  ) => VersionedSourceTransformerBuilder<{
+  ) => SourceTransformerBuilder<{
     _context: TParams["_context"];
     _outputSchema: TParams["_outputSchema"];
     _urls: TParams["_urls"];
@@ -223,7 +223,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
     output: TParams["_output"] extends UnsetMarker
       ? OutputFn<AdapterContext, TIn, TOut>
       : ErrorMessage<"output is already set">,
-  ) => VersionedSourceTransformer<{
+  ) => SourceTransformer<{
     globalContext: TParams["_context"];
     cacheOptions: TParams["_options"]["cacheOptions"];
     fetchOptions: TParams["_options"]["fetchOptions"];
@@ -238,7 +238,7 @@ export interface VersionedSourceTransformerBuilder<TParams extends AnyVersionedS
   }>;
 }
 
-export interface AnyBuiltVersionedSourceTransformerParams {
+export interface AnyBuiltSourceTransformerParams {
   globalContext: AdapterContext;
   fetchOptions: RequestInit;
   cacheOptions: CacheOptions;
@@ -252,7 +252,7 @@ export interface AnyBuiltVersionedSourceTransformerParams {
   output: any;
 }
 
-export interface VersionedSourceTransformer<TParams extends AnyBuiltVersionedSourceTransformerParams> {
+export interface SourceTransformer<TParams extends AnyBuiltSourceTransformerParams> {
   globalContext: TParams["globalContext"];
   fetchOptions: TParams["fetchOptions"];
   cacheOptions: TParams["cacheOptions"];
@@ -265,4 +265,4 @@ export interface VersionedSourceTransformer<TParams extends AnyBuiltVersionedSou
   outputSchema: TParams["outputSchema"];
 }
 
-export type AnyVersionedSourceTransformer = VersionedSourceTransformer<any>;
+export type AnySourceTransformer = SourceTransformer<any>;

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -29,7 +29,7 @@ const builder = createSourceAdapter({
 });
 
 export const handler = builder
-  .onVersion(
+  .withTransform(
     (emoji_version) => !DISALLOWED_EMOJI_VERSIONS.includes(emoji_version),
     (builder) => {
       return builder

--- a/packages/adapters/src/handlers/source/sequences.ts
+++ b/packages/adapters/src/handlers/source/sequences.ts
@@ -40,7 +40,7 @@ const builder = createSourceAdapter({
 });
 
 export const handler = builder
-  .onVersion(
+  .withTransform(
     (version) => !NOT_AVAILABLE_SEQUENCES.includes(version),
     (builder) => builder
       .urls(({ emoji_version }) => {

--- a/packages/adapters/src/handlers/source/unicode-names.ts
+++ b/packages/adapters/src/handlers/source/unicode-names.ts
@@ -17,7 +17,7 @@ const builder = createSourceAdapter({
 });
 
 export const handler = builder
-  .onVersion(
+  .withTransform(
     () => true,
     (builder) => builder
       .urls((ctx) => {

--- a/packages/adapters/src/handlers/source/variations.ts
+++ b/packages/adapters/src/handlers/source/variations.ts
@@ -11,7 +11,7 @@ const builder = createSourceAdapter({
 });
 
 export const handler = builder
-  .onVersion(
+  .withTransform(
     (version) => !UNSUPPORTED_VARIATION_VERSIONS.includes(version),
     (builder) => builder
       .urls((ctx) => {

--- a/packages/adapters/src/runners/source-runner.ts
+++ b/packages/adapters/src/runners/source-runner.ts
@@ -3,7 +3,7 @@ import type { AnySourceAdapter, InferHandlerOutput } from "../builders/source-bu
 import type { AdapterContext } from "../global-types";
 import { arktypeParse } from "@mojis/internal-utils";
 import { AdapterError } from "../errors";
-import { runVersionedSourceTransformer } from "./version-runner";
+import { runSourceTransformer } from "./source-transformer-runner";
 
 export interface RunSourceAdapterOverrides {
   cacheKey?: string;
@@ -28,7 +28,7 @@ export async function runSourceAdapter<
       continue;
     }
 
-    promises.push(runVersionedSourceTransformer(ctx, sourceTransformer, handler.adapterType, __overrides));
+    promises.push(runSourceTransformer(ctx, sourceTransformer, handler.adapterType, __overrides));
   }
 
   const result = await Promise.all(promises);

--- a/packages/adapters/src/runners/source-transformer-runner.ts
+++ b/packages/adapters/src/runners/source-transformer-runner.ts
@@ -1,5 +1,5 @@
 import type { Cache, CacheOptions } from "@mojis/internal-utils";
-import type { AnyVersionedSourceTransformer } from "../builders/version-builder/types";
+import type { AnySourceTransformer } from "../builders/version-builder/types";
 import type { AdapterContext, SourceAdapterType } from "../global-types";
 import { fetchCache } from "@mojis/internal-utils";
 import { genericParse } from "@mojis/parsers";
@@ -7,7 +7,7 @@ import defu from "defu";
 import { AdapterError } from "../errors";
 import { buildContext, getHandlerUrls, isBuiltinParser } from "../utils";
 
-export interface RunVersionedSourceTransformerOverrides {
+export interface RunSourceTransformerOverrides {
   cacheKey?: string;
   cacheOptions?: CacheOptions;
   cache?: Cache<string>;
@@ -16,11 +16,11 @@ export interface RunVersionedSourceTransformerOverrides {
 /**
  * @internal
  */
-export async function runVersionedSourceTransformer<THandler extends AnyVersionedSourceTransformer>(
+export async function runSourceTransformer<THandler extends AnySourceTransformer>(
   ctx: AdapterContext,
   handler: THandler,
   adapterHandlerType: SourceAdapterType,
-  __overrides?: RunVersionedSourceTransformerOverrides,
+  __overrides?: RunSourceTransformerOverrides,
 ): Promise<THandler["output"]> {
   const urls = await getHandlerUrls(handler.urls, ctx);
 

--- a/packages/adapters/test/__utils.ts
+++ b/packages/adapters/test/__utils.ts
@@ -10,7 +10,7 @@ import type {
   PredicateFn,
   SourceAdapter,
 } from "../src/builders/source-builder/types";
-import type { AnyVersionedSourceTransformer, VersionedSourceTransformer } from "../src/builders/version-builder/types";
+import type { AnySourceTransformer, SourceTransformer } from "../src/builders/version-builder/types";
 import type {
   AdapterContext,
   BuiltinParser,
@@ -72,10 +72,10 @@ export function createFakeSourceAdapter<TParams extends AnyBuiltSourceAdapterPar
   };
 }
 
-export type CreateVersionedSourceTransformer<TConfig extends {
+export type CreateSourceTransformer<TConfig extends {
   output: unknown;
   params?: Record<string, any>;
-}> = VersionedSourceTransformer<{
+}> = SourceTransformer<{
   globalContext: AdapterContext;
   fetchOptions: RequestInit;
   cacheOptions: CacheOptions;
@@ -91,7 +91,7 @@ export type CreateVersionedSourceTransformer<TConfig extends {
 
 export interface TestBuiltSourceAdapterParams {
   adapterType: string;
-  handlers: [PredicateFn, AnyVersionedSourceTransformer][];
+  handlers: [PredicateFn, AnySourceTransformer][];
   outputSchema?: type.Any;
   fallback?: FallbackFn<any>;
 }
@@ -110,7 +110,7 @@ export interface TestSourceAdapter<TParams extends TestBuiltSourceAdapterParams>
 export type CreateAnySourceAdapter<
   TType extends string,
   TConfig extends {
-    handlers: CreateVersionedSourceTransformer<any>[];
+    handlers: CreateSourceTransformer<any>[];
     outputSchema?: type.Any;
     fallback?: any;
   },

--- a/packages/adapters/test/builders/adapter-handler.test-d.ts
+++ b/packages/adapters/test/builders/adapter-handler.test-d.ts
@@ -1,14 +1,14 @@
 import type {
   InferHandlerOutput,
 } from "../../src/builders/source-builder/types";
-import type { CreateAnySourceAdapter, CreateVersionedSourceTransformer } from "../__utils";
+import type { CreateAnySourceAdapter, CreateSourceTransformer } from "../__utils";
 import { describe, expectTypeOf, it } from "vitest";
 
 describe("InferHandlerOutput", () => {
   it("should infer the output of an adapter handler", () => {
     type Result = InferHandlerOutput<CreateAnySourceAdapter<"test", {
       handlers: [
-        CreateVersionedSourceTransformer<{ output: string }>,
+        CreateSourceTransformer<{ output: string }>,
       ];
     }>>;
 
@@ -19,7 +19,7 @@ describe("InferHandlerOutput", () => {
     type Result = InferHandlerOutput<CreateAnySourceAdapter<"test", {
       fallback: () => string;
       handlers: [
-        CreateVersionedSourceTransformer<{ output: string }>,
+        CreateSourceTransformer<{ output: string }>,
       ];
     }>>;
 

--- a/packages/adapters/test/builders/adapter-handler.test.ts
+++ b/packages/adapters/test/builders/adapter-handler.test.ts
@@ -21,7 +21,7 @@ describe("adapter handler builder", () => {
   it("adds version handler", () => {
     const builder = createSourceAdapter({ type: "metadata" });
     const handler = builder
-      .onVersion(
+      .withTransform(
         (version) => version === "15.0",
         (builder) => builder
           .urls(() => "https://example.com")
@@ -37,14 +37,14 @@ describe("adapter handler builder", () => {
   it("adds multiple version handlers", () => {
     const builder = createSourceAdapter({ type: "metadata" });
     const handler = builder
-      .onVersion(
+      .withTransform(
         (version) => version === "15.0",
         (builder) => builder
           .urls(() => "v15")
           .parser("generic")
           .output((_, data) => data),
       )
-      .onVersion(
+      .withTransform(
         (version) => version === "14.0",
         (builder) => builder
           .urls(() => "v14")
@@ -61,14 +61,14 @@ describe("adapter handler builder", () => {
   it("maintains handler order", () => {
     const builder = createSourceAdapter({ type: "metadata" });
     const handler = builder
-      .onVersion(
+      .withTransform(
         (version) => version === "15.0",
         (builder) => builder
           .urls(() => "v15")
           .parser("generic")
           .output((_, data) => data),
       )
-      .onVersion(
+      .withTransform(
         (version) => version === "14.0",
         (builder) => builder
           .urls(() => "v14")
@@ -89,14 +89,14 @@ describe("adapter handler builder", () => {
   it("preserves adapter type across chain", () => {
     const builder = createSourceAdapter({ type: "metadata" });
     const handler = builder
-      .onVersion(
+      .withTransform(
         (version) => version === "15.0",
         (builder) => builder
           .urls(() => "v15")
           .parser("generic")
           .output((_, data) => data),
       )
-      .onVersion(
+      .withTransform(
         (version) => version === "14.0",
         (builder) => builder
           .urls(() => "v14")
@@ -111,21 +111,21 @@ describe("adapter handler builder", () => {
   it("allows chaining multiple onVersion calls", () => {
     const builder = createSourceAdapter({ type: "metadata" });
     const handler = builder
-      .onVersion(
+      .withTransform(
         (version) => version === "15.0",
         (builder) => builder
           .urls(() => "v15")
           .parser("generic")
           .output((_, data) => data),
       )
-      .onVersion(
+      .withTransform(
         (version) => version === "14.0",
         (builder) => builder
           .urls(() => "v14")
           .parser("generic")
           .output((_, data) => data),
       )
-      .onVersion(
+      .withTransform(
         (version) => version === "13.0",
         (builder) => builder
           .urls(() => "v13")

--- a/packages/adapters/test/builders/composite-handler.test-d.ts
+++ b/packages/adapters/test/builders/composite-handler.test-d.ts
@@ -7,7 +7,7 @@ import type {
   TransformChain,
 } from "../../src/builders/composite-builder/types";
 import type { UnsetMarker } from "../../src/global-types";
-import type { CreateAnySourceAdapter, CreateVersionedSourceTransformer } from "../__utils";
+import type { CreateAnySourceAdapter, CreateSourceTransformer } from "../__utils";
 import { describe, expectTypeOf, it } from "vitest";
 
 type LengthOf<T extends any[]> = T["length"] extends infer L
@@ -35,14 +35,14 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"version", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: number;
           }>,
         ];
       }>,
       CreateAnySourceAdapter<"world", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string;
           }>,
         ];
@@ -65,14 +65,14 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"version", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string;
           }>,
         ];
       }>,
       CreateAnySourceAdapter<"hello", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: number;
           }>,
         ];
@@ -97,14 +97,14 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"array", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string[];
           }>,
         ];
       }>,
       CreateAnySourceAdapter<"object", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: { key: string };
           }>,
         ];
@@ -131,7 +131,7 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"version", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string;
           }>,
         ];
@@ -154,7 +154,7 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"complex", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: {
               nested: {
                 value: number;
@@ -189,7 +189,7 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"dynamic", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string;
           }>,
         ];
@@ -212,14 +212,14 @@ describe("MergeSources", () => {
     type Source2 = [
       CreateAnySourceAdapter<"same", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: string;
           }>,
         ];
       }>,
       CreateAnySourceAdapter<"same", {
         handlers: [
-          CreateVersionedSourceTransformer<{
+          CreateSourceTransformer<{
             output: number;
           }>,
         ];
@@ -254,7 +254,7 @@ describe("MergeSources", () => {
       type Source2 = [
         CreateAnySourceAdapter<"version", {
           handlers: [
-            CreateVersionedSourceTransformer<{
+            CreateSourceTransformer<{
               output: string;
             }>,
           ];

--- a/packages/adapters/test/builders/source-transformer-handler.test.ts
+++ b/packages/adapters/test/builders/source-transformer-handler.test.ts
@@ -1,13 +1,13 @@
 import type { GenericParseResult } from "@mojis/parsers";
 import type { AdapterContext } from "../../src/global-types";
 import { describe, expect, it } from "vitest";
-import { createVersionedSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
+import { createSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
 
 describe("version handler builder", () => {
   const emptyContext = {} as AdapterContext;
 
   it("creates basic handler", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .output((_, data) => data);
@@ -17,7 +17,7 @@ describe("version handler builder", () => {
   });
 
   it("sets urls with cache options", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => ({
         url: "https://example.com",
         cacheKey: "test",
@@ -33,7 +33,7 @@ describe("version handler builder", () => {
   });
 
   it("sets parser with options", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic", { separator: ";" })
       .output((_, data) => data);
@@ -43,7 +43,7 @@ describe("version handler builder", () => {
   });
 
   it("transforms data", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .transform((_, data) => ({ ...data, transformed: true }))
@@ -55,7 +55,7 @@ describe("version handler builder", () => {
   });
 
   it("aggregates data", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .transform((_, data) => data)
@@ -71,7 +71,7 @@ describe("version handler builder", () => {
   });
 
   it("sets cache options", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .cacheOptions({ ttl: 3600 })
@@ -81,7 +81,7 @@ describe("version handler builder", () => {
   });
 
   it("sets fetch options", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .fetchOptions({ method: "GET" })
@@ -91,7 +91,7 @@ describe("version handler builder", () => {
   });
 
   it("chains all options", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => ({
         url: "https://example.com",
         cacheKey: "test",
@@ -124,7 +124,7 @@ describe("version handler builder", () => {
   });
 
   it("maintains order of operations", () => {
-    const handler = createVersionedSourceTransformerBuilder()
+    const handler = createSourceTransformerBuilder()
       .urls(() => "https://example.com")
       .parser("generic")
       .transform((_, data) => ({ ...data, step1: true, step2: true }))
@@ -151,7 +151,7 @@ describe("version handler builder", () => {
   });
 
   it("validates data", () => {
-    const handler = createVersionedSourceTransformerBuilder<{
+    const handler = createSourceTransformerBuilder<{
       id: string;
     }>()
       .urls(() => "https://example.com")

--- a/packages/adapters/test/global-types.test-d.ts
+++ b/packages/adapters/test/global-types.test-d.ts
@@ -1,6 +1,6 @@
 import type { GenericParseOptions } from "@mojis/parsers";
 import type { PredicateFn } from "../src/builders/source-builder/types";
-import type { AnyVersionedSourceTransformer, GetParseOptionsFromParser } from "../src/builders/version-builder/types";
+import type { AnySourceTransformer, GetParseOptionsFromParser } from "../src/builders/version-builder/types";
 import type { MergeTuple } from "../src/global-types";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -47,19 +47,19 @@ describe("JoinTuples", () => {
 
   it("merge adapter handlers", () => {
     type Handlers = [
-      [PredicateFn, AnyVersionedSourceTransformer],
-      [PredicateFn, AnyVersionedSourceTransformer],
+      [PredicateFn, AnySourceTransformer],
+      [PredicateFn, AnySourceTransformer],
     ];
 
     type Result = MergeTuple<
       Handlers,
-      [[PredicateFn, AnyVersionedSourceTransformer]]
+      [[PredicateFn, AnySourceTransformer]]
     >;
 
     expectTypeOf<Result>().toExtend<[
-      [PredicateFn, AnyVersionedSourceTransformer],
-      [PredicateFn, AnyVersionedSourceTransformer],
-      [PredicateFn, AnyVersionedSourceTransformer],
+      [PredicateFn, AnySourceTransformer],
+      [PredicateFn, AnySourceTransformer],
+      [PredicateFn, AnySourceTransformer],
     ]>();
   });
 });

--- a/packages/adapters/test/runners/composite-runner.test.ts
+++ b/packages/adapters/test/runners/composite-runner.test.ts
@@ -4,7 +4,7 @@ import { HttpResponse, mockFetch } from "#msw-utils";
 import { type } from "arktype";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createCompositeHandlerBuilder } from "../../src/builders/composite-builder/builder";
-import { createVersionedSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
+import { createSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
 import { createFakeSourceAdapter, setupAdapterTest } from "../__utils";
 
 describe("run composite handler", () => {
@@ -72,7 +72,7 @@ describe("run composite handler", () => {
       }],
     ]);
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/test")
       .parser((_, data) => data)
       .transform((_, data) => data)
@@ -123,7 +123,7 @@ describe("run composite handler", () => {
       }],
     ]);
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/test")
       .parser((_, data) => data)
       .transform((_, data) => data)
@@ -185,7 +185,7 @@ describe("run composite handler", () => {
         }],
       ]);
 
-      const nameHandler = createVersionedSourceTransformerBuilder()
+      const nameHandler = createSourceTransformerBuilder()
         .urls(() => "https://mojis.dev/random-name")
         .parser((_, data) => data)
         .transform((_, data) => data)

--- a/packages/adapters/test/runners/source-runner.test.ts
+++ b/packages/adapters/test/runners/source-runner.test.ts
@@ -3,7 +3,7 @@ import type { AdapterContext } from "../../src/global-types";
 import { HttpResponse, mockFetch } from "#msw-utils";
 import { type } from "arktype";
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { createVersionedSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
+import { createSourceTransformerBuilder } from "../../src/builders/version-builder/builder";
 import { createFakeSourceAdapter, setupAdapterTest } from "../__utils";
 
 describe("runSourceAdapter", () => {
@@ -48,13 +48,13 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-matching-version-handler/1")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler1" }))
       .output((_, data) => ({ processedBy: data.processed }));
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-matching-version-handler/2")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler2" }))
@@ -94,19 +94,19 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler1 = createVersionedSourceTransformerBuilder()
+    const mockHandler1 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-first-matching-version-handler/1")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler1" }))
       .output((_, data) => ({ processedBy: data.processed }));
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-first-matching-version-handler/2")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler2" }))
       .output((_, data) => ({ processedBy: data.processed }));
 
-    const mockHandler3 = createVersionedSourceTransformerBuilder()
+    const mockHandler3 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-first-matching-version-handler/3")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler3" }))
@@ -144,7 +144,7 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => [
         "https://mojis.dev/run-multiple-urls/1",
         "https://mojis.dev/run-multiple-urls/2",
@@ -154,7 +154,7 @@ describe("runSourceAdapter", () => {
       .aggregate((_, data) => data)
       .output((_, data) => ({ processedBy: data[0]?.processed }));
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-multiple-urls/3")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler2" }))
@@ -194,14 +194,14 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-transformation-and-aggregation/1")
       .parser("generic")
       .transform((_, data) => ({ ...data, transformed: true }))
       .aggregate((_, data) => ({ ...data[0], aggregated: true }))
       .output((_, data) => data);
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-transformation-and-aggregation/2")
       .parser("generic")
       .transform((_, data) => ({ ...data, transformed: true }))
@@ -241,7 +241,7 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-cache-and-fetch-options/1")
       .parser("generic")
       .cacheOptions({ ttl: 3600 })
@@ -249,7 +249,7 @@ describe("runSourceAdapter", () => {
       .transform((_, data) => ({ ...data, processed: "handler1" }))
       .output((_, data) => ({ processedBy: data.processed }));
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-cache-and-fetch-options/2")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler2" }))
@@ -283,13 +283,13 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler1 = createVersionedSourceTransformerBuilder()
+    const mockHandler1 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-force-mode/1")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler1" }))
       .output((_, data) => ({ processedBy: data.processed }));
 
-    const mockHandler2 = createVersionedSourceTransformerBuilder()
+    const mockHandler2 = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/run-force-mode/2")
       .parser("generic")
       .transform((_, data) => ({ ...data, processed: "handler2" }))
@@ -332,7 +332,7 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder()
+    const mockHandler = createSourceTransformerBuilder()
       .urls(() => "https://mojis.dev/test")
       .parser("generic")
       .cacheOptions({ ttl: 3600 })
@@ -374,7 +374,7 @@ describe("runSourceAdapter", () => {
 
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder<{
+    const mockHandler = createSourceTransformerBuilder<{
       page?: string;
     }>()
       .urls(() => "https://mojis.dev/handle-validation")
@@ -403,7 +403,7 @@ describe("runSourceAdapter", () => {
       HttpResponse.text("mojis.dev/handle-validation-fail"));
     const { runSourceAdapter } = await setupAdapterTest();
 
-    const mockHandler = createVersionedSourceTransformerBuilder<{
+    const mockHandler = createSourceTransformerBuilder<{
       page1: string;
     }>()
       .urls(() => "https://mojis.dev/handle-validation-fail")


### PR DESCRIPTION
fixes #100 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package patch version for improved stability.

- **Refactor**
  - Standardized transformation handling by replacing version-specific terminology with a unified "source transformer" approach.
  - Renamed the configuration method from `.onVersion()` to `.withTransform()` and updated related builder and runner functions for a more consistent API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->