### PR TITLE
refactor: migrate to new persistence

### DIFF
--- a/.changeset/public-ties-jog.md
+++ b/.changeset/public-ties-jog.md
@@ -1,0 +1,5 @@
+---
+"@mojis/adapters": minor
+---
+
+refactor: migrate to new persistence

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -22,12 +22,16 @@ function internalCreateSourceAdapterBuilder<
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
     _fallback: UnsetMarker;
+    _persistence: PersistenceContext;
+    _persistenceMapFn: any;
   }> {
   const _def: AnySourceAdapter = {
     adapterType: initDef.adapterType,
     transformerOutputSchema: initDef.transformerOutputSchema,
     handlers: [],
     fallback: () => {},
+    persistence: initDef.persistence ?? {} as PersistenceContext,
+    persistenceMapFn: () => { return []; },
 
     // overload with properties passed in
     ...initDef,
@@ -50,6 +54,12 @@ function internalCreateSourceAdapterBuilder<
       return internalCreateSourceAdapterBuilder({
         ..._def,
         fallback: userFn,
+      }) as SourceAdapterBuilder<any>;
+    },
+    toPersistenceOperations(userFn) {
+      return internalCreateSourceAdapterBuilder({
+        ..._def,
+        persistenceMapFn: userFn,
       }) as SourceAdapterBuilder<any>;
     },
     build() {
@@ -80,9 +90,12 @@ export function createSourceAdapter<
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
     _fallback: UnsetMarker;
+    _persistence: PersistenceContext;
+    _persistenceMapFn: any;
   }> {
   return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema>({
     adapterType: opts.type,
     transformerOutputSchema: opts.transformerOutputSchema,
+    persistence: opts.persistence,
   });
 }

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -14,22 +14,17 @@ import { createSourceTransformerBuilder } from "../source-transformer-builder/bu
 function internalCreateSourceAdapterBuilder<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
-  TPersistenceOutputSchema extends type.Any,
 >(
   initDef: Partial<AnySourceAdapter> = {},
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
-    _persistenceOutputSchema: TPersistenceOutputSchema;
     _fallback: UnsetMarker;
-    _persistence: UnsetMarker;
-    _persistenceOptions: UnsetMarker;
   }> {
   const _def: AnySourceAdapter = {
     adapterType: initDef.adapterType,
     transformerOutputSchema: initDef.transformerOutputSchema,
-    persistenceOutputSchema: initDef.persistenceOutputSchema,
     handlers: [],
     fallback: () => {},
 
@@ -56,18 +51,6 @@ function internalCreateSourceAdapterBuilder<
         fallback: userFn,
       }) as SourceAdapterBuilder<any>;
     },
-    persistence(userFn) {
-      return internalCreateSourceAdapterBuilder({
-        ..._def,
-        persistence: userFn,
-      }) as SourceAdapterBuilder<any>;
-    },
-    persistenceOptions(userOptions) {
-      return internalCreateSourceAdapterBuilder({
-        ..._def,
-        persistenceOptions: userOptions,
-      }) as SourceAdapterBuilder<any>;
-    },
     build() {
       return _def;
     },
@@ -77,35 +60,27 @@ function internalCreateSourceAdapterBuilder<
 export interface CreateSourceAdapterBuilderOptions<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
-  TPersistenceOutputSchema extends type.Any,
 > {
   type: TAdapterType;
   transformerOutputSchema: TTransformerOutputSchema;
-  persistenceOutputSchema?: TPersistenceOutputSchema;
 }
 
 export function createSourceAdapter<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
-  TPersistenceOutputSchema extends type.Any,
 >(
   opts: CreateSourceAdapterBuilderOptions<
     TAdapterType,
-    TTransformerOutputSchema,
-    TPersistenceOutputSchema
+    TTransformerOutputSchema
   >,
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
-    _persistenceOutputSchema: TPersistenceOutputSchema;
     _fallback: UnsetMarker;
-    _persistence: UnsetMarker;
-    _persistenceOptions: UnsetMarker;
   }> {
-  return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema, TPersistenceOutputSchema>({
+  return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema>({
     adapterType: opts.type,
     transformerOutputSchema: opts.transformerOutputSchema,
-    persistenceOutputSchema: opts.persistenceOutputSchema,
   });
 }

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -6,6 +6,7 @@ import type {
 import type { AnySourceTransformer } from "../source-transformer-builder/types";
 import type {
   AnySourceAdapter,
+  PersistenceContext,
   PredicateFn,
   SourceAdapterBuilder,
 } from "./types";
@@ -63,6 +64,7 @@ export interface CreateSourceAdapterBuilderOptions<
 > {
   type: TAdapterType;
   transformerOutputSchema: TTransformerOutputSchema;
+  persistence: PersistenceContext;
 }
 
 export function createSourceAdapter<

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -15,6 +15,7 @@ import { createSourceTransformerBuilder } from "../source-transformer-builder/bu
 function internalCreateSourceAdapterBuilder<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
+  TPersistence extends PersistenceContext,
 >(
   initDef: Partial<AnySourceAdapter> = {},
 ): SourceAdapterBuilder<{
@@ -22,7 +23,7 @@ function internalCreateSourceAdapterBuilder<
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
     _fallback: UnsetMarker;
-    _persistence: PersistenceContext;
+    _persistence: TPersistence;
     _persistenceMapFn: any;
   }> {
   const _def: AnySourceAdapter = {
@@ -71,29 +72,32 @@ function internalCreateSourceAdapterBuilder<
 export interface CreateSourceAdapterBuilderOptions<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
+  TPersistence extends PersistenceContext,
 > {
   type: TAdapterType;
   transformerOutputSchema: TTransformerOutputSchema;
-  persistence: PersistenceContext;
+  persistence: TPersistence;
 }
 
 export function createSourceAdapter<
   TAdapterType extends SourceAdapterType,
   TTransformerOutputSchema extends type.Any,
+  TPersistence extends PersistenceContext,
 >(
   opts: CreateSourceAdapterBuilderOptions<
     TAdapterType,
-    TTransformerOutputSchema
+    TTransformerOutputSchema,
+    TPersistence
   >,
 ): SourceAdapterBuilder<{
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
     _fallback: UnsetMarker;
-    _persistence: PersistenceContext;
+    _persistence: TPersistence;
     _persistenceMapFn: any;
   }> {
-  return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema>({
+  return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema, TPersistence>({
     adapterType: opts.type,
     transformerOutputSchema: opts.transformerOutputSchema,
     persistence: opts.persistence,

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -1,6 +1,7 @@
 import type { type } from "arktype";
 import type {
   ErrorMessage,
+  MaybePromise,
   MergeTuple,
   SourceAdapterType,
   UnsetMarker,
@@ -10,6 +11,45 @@ import type {
   AnySourceTransformerParams,
   SourceTransformerBuilder,
 } from "../source-transformer-builder/types";
+
+export interface PersistenceOptions {
+  /**
+   * The base path to use for the output files.
+   * @default "./data/v<emoji-version>"
+   */
+  basePath: string;
+
+  /**
+   * Whether to pretty-print the if `output` is JSON.
+   * @default false
+   */
+  pretty?: boolean;
+
+  /**
+   * The encoding to use when writing files.
+   * @default "utf-8"
+   */
+  encoding?: BufferEncoding;
+}
+
+interface PersistenceSchema {
+  pattern: string;
+  filePath: string;
+  type: "json" | "text";
+  schema: type.Any;
+}
+
+export interface PersistenceContext {
+  /**
+   * Persistence Schemas
+   */
+  schemas: Record<string, PersistenceSchema>;
+
+  /**
+   * The persistence options to use.
+   */
+  options?: PersistenceOptions;
+}
 
 export type InferHandlerOutput<TSourceAdapter extends AnySourceAdapter> =
   TSourceAdapter extends { handlers: Array<[any, infer TSourceTransformer]> }

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -67,10 +67,11 @@ export interface PersistenceContext<TSchemas extends Record<string, PersistenceS
 export type PersistenceMapFn<
   TContext extends PersistenceContext,
   TIn,
+  TOut extends ValidSchemaOp<TContext>,
 > = (
   references: TContext["schemas"],
   data: TIn
-) => MaybePromise<Array<ValidSchemaOp<TContext>>>;
+) => MaybePromise<Array<TOut>>;
 
 export type InferHandlerOutput<TSourceAdapter extends AnySourceAdapter> =
   TSourceAdapter extends { handlers: Array<[any, infer TSourceTransformer]> }
@@ -119,15 +120,16 @@ export interface SourceAdapterBuilder<
 
   toPersistenceOperations: <
     TIn extends TParams["_transformerOutputSchema"]["infer"],
+    TOut extends ValidSchemaOp<TParams["_persistence"]>,
   >(
-    fn: PersistenceMapFn<TParams["_persistence"], TIn>
+    fn: PersistenceMapFn<TParams["_persistence"], TIn, TOut>
   ) => SourceAdapterBuilder<{
     _adapterType: TParams["_adapterType"];
     _transformerOutputSchema: TParams["_transformerOutputSchema"];
     _handlers: TParams["_handlers"];
     _fallback: TParams["_fallback"];
     _persistence: TParams["_persistence"];
-    _persistenceMapFn: typeof fn;
+    _persistenceMapFn: TOut;
   }>;
 
   build: () => SourceAdapter<{
@@ -160,7 +162,7 @@ export interface AnyBuiltSourceAdapterParams {
   fallback?: FallbackFn<any>;
   transformerOutputSchema: type.Any;
   persistence: PersistenceContext;
-  persistenceMapFn: PersistenceMapFn<any, any>;
+  persistenceMapFn: any;
 }
 
 export type FallbackFn<TOut> = () => TOut;
@@ -175,7 +177,7 @@ export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
       : any
   >;
   persistence: TParams["persistence"];
-  persistenceMapFn: PersistenceMapFn<TParams["persistence"], TParams["transformerOutputSchema"]["infer"]>;
+  persistenceMapFn: PersistenceMapFn<TParams["persistence"], TParams["transformerOutputSchema"]["infer"], TParams["persistenceMapFn"]>;
 }
 
 export type AnySourceAdapter = SourceAdapter<any>;

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -1,7 +1,6 @@
 import type { type } from "arktype";
 import type {
   ErrorMessage,
-  Id,
   MaybePromise,
   MergeTuple,
   SourceAdapterType,

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -1,7 +1,6 @@
 import type { type } from "arktype";
 import type {
   ErrorMessage,
-  MaybePromise,
   MergeTuple,
   SourceAdapterType,
   UnsetMarker,
@@ -11,104 +10,6 @@ import type {
   AnySourceTransformerParams,
   SourceTransformerBuilder,
 } from "../source-transformer-builder/types";
-
-export interface PersistenceOptions {
-  /**
-   * The base path to use for the output files.
-   * @default "./data/v<emoji-version>"
-   */
-  basePath: string;
-
-  /**
-   * Whether to force overwrite of existing files.
-   * @default false
-   */
-  force?: boolean;
-
-  /**
-   * Version information for the emoji data.
-   */
-  version: {
-    /**
-     * The emoji version.
-     */
-    emoji_version: string;
-
-    /**
-     * The unicode version.
-     */
-    unicode_version: string;
-  };
-
-  /**
-   * Whether to pretty-print the output JSON.
-   * @default false
-   */
-  pretty?: boolean;
-
-  /**
-   * The file extension to use for the output files.
-   * @default "json"
-   */
-  fileExtension?: string;
-
-  /**
-   * The encoding to use when writing files.
-   * @default "utf-8"
-   */
-  encoding?: BufferEncoding;
-}
-
-export interface PersistenceFileOperation<TData = string | Uint8Array> {
-  /**
-   * The file path to write to.
-   */
-  filePath: string;
-
-  /**
-   * The data to write to the file.
-   */
-  data: TData;
-
-  /**
-   * The type of data being written.
-   */
-  type: "json" | "text";
-
-  /**
-   * The options for the file operation.
-   */
-  options?: {
-    /**
-     * For JSON, whether to pretty-print.
-     * @default false
-     */
-    pretty?: boolean;
-
-    /**
-     * The encoding to use for the file.
-     * @default "utf-8"
-     */
-    encoding?: BufferEncoding;
-
-    /**
-     * Whether to overwrite existing files.
-     */
-    force?: boolean;
-  };
-}
-
-export type PersistenceFn<TIn, TOut> = (
-  data: TIn,
-  options: PersistenceOptions
-) => MaybePromise<
-  Array<
-    PersistenceFileOperation<
-      TOut extends (infer ArrayType)[] ? ArrayType[] :
-        keyof TOut extends never ? unknown : TOut[keyof TOut]
-    >
-  >
->;
 
 export type InferHandlerOutput<TSourceAdapter extends AnySourceAdapter> =
   TSourceAdapter extends { handlers: Array<[any, infer TSourceTransformer]> }
@@ -133,9 +34,6 @@ export interface SourceAdapterBuilder<
   ) => SourceAdapterBuilder<{
     _adapterType: TParams["_adapterType"];
     _transformerOutputSchema: TParams["_transformerOutputSchema"];
-    _persistenceOutputSchema: TParams["_persistenceOutputSchema"];
-    _persistence: TParams["_persistence"];
-    _persistenceOptions: TParams["_persistenceOptions"];
     _handlers: MergeTuple<
       [[TPredicate, THandler]],
       TParams["_handlers"]
@@ -151,48 +49,13 @@ export interface SourceAdapterBuilder<
     _fallback: TOut;
     _handlers: TParams["_handlers"];
     _transformerOutputSchema: TParams["_transformerOutputSchema"];
-    _persistenceOutputSchema: TParams["_persistenceOutputSchema"];
-    _persistence: TParams["_persistence"];
-    _persistenceOptions: TParams["_persistenceOptions"];
     _adapterType: TParams["_adapterType"];
-  }>;
-
-  persistence: <
-    TIn extends TParams["_transformerOutputSchema"] extends type.Any ? TParams["_transformerOutputSchema"]["infer"] : any,
-    TOut extends TParams["_persistenceOutputSchema"] extends type.Any ? TParams["_persistenceOutputSchema"]["infer"] : any,
-  >(
-    fn: TParams["_persistence"] extends UnsetMarker
-      ? PersistenceFn<TIn, TOut>
-      : ErrorMessage<"persistence is already set">,
-  ) => SourceAdapterBuilder<{
-    _fallback: TOut;
-    _handlers: TParams["_handlers"];
-    _persistenceOutputSchema: TParams["_persistenceOutputSchema"];
-    _transformerOutputSchema: TParams["_transformerOutputSchema"];
-    _adapterType: TParams["_adapterType"];
-    _persistence: TOut;
-    _persistenceOptions: TParams["_persistenceOptions"];
-  }>;
-
-  persistenceOptions: <TOptions extends Omit<PersistenceOptions, "version">>(
-    options: TOptions extends UnsetMarker ? TOptions : ErrorMessage<"persistenceOptions is already set">
-  ) => SourceAdapterBuilder<{
-    _fallback: TParams["_fallback"];
-    _handlers: TParams["_handlers"];
-    _persistenceOutputSchema: TParams["_persistenceOutputSchema"];
-    _transformerOutputSchema: TParams["_transformerOutputSchema"];
-    _adapterType: TParams["_adapterType"];
-    _persistence: TParams["_persistence"];
-    _persistenceOptions: TOptions;
   }>;
 
   build: () => SourceAdapter<{
     fallback: TParams["_fallback"];
     handlers: TParams["_handlers"];
     transformerOutputSchema: TParams["_transformerOutputSchema"];
-    persistenceOutputSchema: TParams["_persistenceOutputSchema"];
-    persistence: TParams["_persistence"];
-    persistenceOptions: TParams["_persistenceOptions"];
     adapterType: TParams["_adapterType"];
   }>;
 }
@@ -201,11 +64,6 @@ export interface AnySourceAdapterParams {
   _adapterType: SourceAdapterType;
   _handlers: [PredicateFn, AnySourceTransformer][];
   _fallback: any;
-  _persistence: any;
-  _persistenceOptions: any;
-
-  // schema for persistence output
-  _persistenceOutputSchema?: type.Any;
 
   // schema for transformer output
   _transformerOutputSchema: type.Any;
@@ -217,10 +75,6 @@ export interface AnyBuiltSourceAdapterParams {
   adapterType: SourceAdapterType;
   handlers: [PredicateFn, AnySourceTransformer][];
   fallback?: FallbackFn<any>;
-  persistenceOptions?: PersistenceOptions;
-  persistence?: PersistenceFn<any, any>;
-
-  persistenceOutputSchema?: type.Any;
   transformerOutputSchema: type.Any;
 }
 
@@ -230,21 +84,11 @@ export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
   adapterType: TParams["adapterType"];
   handlers: TParams["handlers"];
   transformerOutputSchema: TParams["transformerOutputSchema"];
-  persistenceOutputSchema?: TParams["persistenceOutputSchema"];
   fallback?: FallbackFn<
     TParams["transformerOutputSchema"] extends type.Any
       ? TParams["transformerOutputSchema"]["infer"]
       : any
   >;
-  persistence?: PersistenceFn<
-    TParams["transformerOutputSchema"] extends type.Any
-      ? TParams["transformerOutputSchema"]["infer"]
-      : any,
-    TParams["persistenceOutputSchema"] extends type.Any
-      ? TParams["persistenceOutputSchema"]["infer"]
-      : any
-  >;
-  persistenceOptions?: TParams["persistenceOptions"];
 }
 
 export type AnySourceAdapter = SourceAdapter<any>;

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -39,11 +39,11 @@ export interface PersistenceSchema {
   schema: type.Any;
 }
 
-export interface PersistenceContext {
+export interface PersistenceContext<TSchemas extends Record<string, PersistenceSchema> = Record<string, PersistenceSchema>> {
   /**
    * Persistence Schemas
    */
-  schemas: Record<string, PersistenceSchema>;
+  schemas: TSchemas;
 
   /**
    * The persistence options to use.
@@ -52,11 +52,11 @@ export interface PersistenceContext {
 }
 
 export type PersistenceMapFn<
-  TReferences extends Record<string, PersistenceSchema>,
+  TContext extends PersistenceContext,
   TIn,
   TOut = any,
 > = (
-  references: TReferences,
+  references: TContext["schemas"],
   data: TIn,
 ) => TOut[];
 
@@ -106,11 +106,10 @@ export interface SourceAdapterBuilder<
   }>;
 
   toPersistenceOperations: <
-    TReferences extends TParams["_persistence"]["schemas"],
     TIn extends TParams["_transformerOutputSchema"]["infer"],
     TOut,
   >(
-    fn: PersistenceMapFn<TReferences, TIn, TOut>,
+    fn: PersistenceMapFn<TParams["_persistence"], TIn, TOut>,
   ) => SourceAdapterBuilder<{
     _adapterType: TParams["_adapterType"];
     _transformerOutputSchema: TParams["_transformerOutputSchema"];
@@ -165,7 +164,7 @@ export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
       : any
   >;
   persistence: TParams["persistence"];
-  persistenceMapFn: PersistenceMapFn<TParams["persistence"]["schemas"], TParams["transformerOutputSchema"]["infer"]>;
+  persistenceMapFn: PersistenceMapFn<TParams["persistence"], TParams["transformerOutputSchema"]["infer"]>;
 }
 
 export type AnySourceAdapter = SourceAdapter<any>;

--- a/packages/adapters/src/global-types.ts
+++ b/packages/adapters/src/global-types.ts
@@ -94,3 +94,14 @@ export type GetSourceAdapterFromType<
   : never;
 
 export type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+
+export type JoinPaths<Parts extends readonly string[]> = Parts extends [] ? "" :
+  Parts extends [infer First] ?
+    First extends string ? First : string :
+    Parts extends [infer First, ...infer Rest] ?
+      First extends string ?
+        Rest extends readonly string[] ?
+  `${First}${Rest[0] extends string ? "/" : "/"}${JoinPaths<Rest>}` :
+          string :
+        string :
+      string;

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -180,13 +180,14 @@ export const handler = builder
         reference: references.groups,
         data: data.groups,
       },
-      ...Object.entries(data.emojis).map(([group, metadata]) => ({
-        reference: references.emojis,
-        params: {
-          group,
-        },
-        data: metadata,
-      })),
+      {
+        reference: references.groups,
+        data: data.emojis.dsa!,
+      },
+      // ...Object.entries(data.emojis).map(([group, metadata]) => ({
+      //   reference: references.emojis,
+      //   data: metadata,
+      // })),
     ];
   })
   .build();

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -46,21 +46,6 @@ const builder = createSourceAdapter({
         schema: GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA,
       },
     },
-    map: (data) => {
-      return [
-        {
-          reference: "groups",
-          data: data.groups,
-        },
-        ...Object.entries(data.emojis).map(([group, metadata]) => ({
-          reference: "emojis",
-          params: {
-            group,
-          },
-          data: metadata,
-        })),
-      ];
-    },
   },
 });
 
@@ -189,4 +174,18 @@ export const handler = builder
       groups: [],
     };
   })
-  .build();
+  .map((references, data) => {
+    return [
+      {
+        reference: references.groups,
+        data: data.groups,
+      },
+      ...Object.entries(data.emojis).map(([group, metadata]) => ({
+        reference: references.emojis,
+        params: {
+          group,
+        },
+        data: metadata,
+      })),
+    ];
+  });

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -180,14 +180,11 @@ export const handler = builder
         reference: references.groups,
         data: data.groups,
       },
-      {
-        reference: references.groups,
-        data: data.emojis.dsa!,
-      },
-      // ...Object.entries(data.emojis).map(([group, metadata]) => ({
-      //   reference: references.emojis,
-      //   data: metadata,
-      // })),
+      ...Object.entries(data.emojis).map(([group, metadata]) => ({
+        reference: references.emojis,
+        params: { group },
+        data: metadata,
+      })),
     ];
   })
   .build();

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -1,9 +1,9 @@
 import type { EmojiGroup, GroupedEmojiMetadata } from "@mojis/schemas/emojis";
-import { join } from "node:path";
 import { extractEmojiVersion, extractUnicodeVersion, isBefore } from "@mojis/internal-utils";
 import { EMOJI_GROUPS_SCHEMA, GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA, GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA } from "@mojis/schemas/emojis";
 import { type } from "arktype";
 import { createSourceAdapter } from "../../builders/source-builder/builder";
+import { joinPath } from "../../utils";
 
 function slugify(val: string): string {
   return val.normalize("NFD")
@@ -27,10 +27,41 @@ const builder = createSourceAdapter({
     groups: EMOJI_GROUPS_SCHEMA,
     emojis: GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA,
   }),
-  persistenceOutputSchema: type({
-    groups: EMOJI_GROUPS_SCHEMA,
-    emojis: GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA,
-  }),
+  persistence: {
+    schemas: {
+      groups: {
+        pattern: "**/groups.json",
+        get filePath() {
+          return joinPath("<base-path>", "groups.json");
+        },
+        type: "json",
+        schema: EMOJI_GROUPS_SCHEMA,
+      },
+      emojis: {
+        pattern: "**/metadata/*.json",
+        get filePath() {
+          return joinPath("<base-path>", "metadata", "{group}.json");
+        },
+        type: "json",
+        schema: GROUPED_BY_HEXCODE_EMOJI_METADATA_SCHEMA,
+      },
+    },
+    map: (data) => {
+      return [
+        {
+          reference: "groups",
+          data: data.groups,
+        },
+        ...Object.entries(data.emojis).map(([group, metadata]) => ({
+          reference: "emojis",
+          params: {
+            group,
+          },
+          data: metadata,
+        })),
+      ];
+    },
+  },
 });
 
 export const handler = builder
@@ -157,19 +188,5 @@ export const handler = builder
       emojis: {},
       groups: [],
     };
-  })
-  .persistence((data, opts) => {
-    return [
-      {
-        filePath: join(opts.basePath, "groups.json"),
-        data: data.groups,
-        type: "json" as const,
-      },
-      ...Object.entries(data.emojis).map(([group, metadata]) => ({
-        filePath: join(opts.basePath, "metadata", `${group}.json`),
-        data: metadata,
-        type: "json" as const,
-      })),
-    ];
   })
   .build();

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -174,7 +174,7 @@ export const handler = builder
       groups: [],
     };
   })
-  .map((references, data) => {
+  .toPersistenceOperations((references, data) => {
     return [
       {
         reference: references.groups,
@@ -188,4 +188,5 @@ export const handler = builder
         data: metadata,
       })),
     ];
-  });
+  })
+  .build();

--- a/packages/adapters/src/handlers/source/sequences.ts
+++ b/packages/adapters/src/handlers/source/sequences.ts
@@ -58,18 +58,6 @@ const builder = createSourceAdapter({
         schema: EMOJI_SEQUENCE_SCHEMA.array(),
       },
     },
-    map: (data) => {
-      return [
-        {
-          reference: "sequences",
-          data: data.sequences,
-        },
-        {
-          reference: "zwj",
-          data: data.zwj,
-        },
-      ];
-    },
   },
 });
 
@@ -161,5 +149,17 @@ export const handler = builder
       sequences: [],
       zwj: [],
     };
+  })
+  .toPersistenceOperations((references, data) => {
+    return [
+      {
+        reference: references.sequences,
+        data: data.sequences,
+      },
+      {
+        reference: references.zwj,
+        data: data.zwj,
+      },
+    ];
   })
   .build();

--- a/packages/adapters/src/handlers/source/sequences.ts
+++ b/packages/adapters/src/handlers/source/sequences.ts
@@ -1,5 +1,4 @@
 import type { EmojiSequence } from "@mojis/schemas/emojis";
-import { join } from "node:path";
 import { expandHexRange, FEMALE_SIGN, MALE_SIGN } from "@mojis/internal-utils";
 import { EMOJI_SEQUENCE_SCHEMA } from "@mojis/schemas/emojis";
 import { type } from "arktype";

--- a/packages/adapters/src/handlers/source/unicode-names.ts
+++ b/packages/adapters/src/handlers/source/unicode-names.ts
@@ -1,4 +1,3 @@
-import { join } from "node:path";
 import { type } from "arktype";
 import { createSourceAdapter } from "../../builders/source-builder/builder";
 import { joinPath } from "../../utils";

--- a/packages/adapters/src/handlers/source/unicode-names.ts
+++ b/packages/adapters/src/handlers/source/unicode-names.ts
@@ -29,14 +29,6 @@ const builder = createSourceAdapter({
         }),
       },
     },
-    map: (data) => {
-      return [
-        {
-          reference: "unicodeNames",
-          data,
-        },
-      ];
-    },
   },
 });
 
@@ -75,5 +67,13 @@ export const handler = builder
   )
   .fallback(() => {
     return {};
+  })
+  .toPersistenceOperations((references, data) => {
+    return [
+      {
+        reference: references.unicodeNames,
+        data,
+      },
+    ];
   })
   .build();

--- a/packages/adapters/src/handlers/source/variations.ts
+++ b/packages/adapters/src/handlers/source/variations.ts
@@ -20,14 +20,6 @@ const builder = createSourceAdapter({
         schema: EMOJI_VARIATION_SCHEMA.array(),
       },
     },
-    map: (data) => {
-      return [
-        {
-          reference: "variations",
-          data,
-        },
-      ];
-    },
   },
 });
 
@@ -82,5 +74,13 @@ export const handler = builder
   )
   .fallback(() => {
     return [];
+  })
+  .toPersistenceOperations((references, data) => {
+    return [
+      {
+        reference: references.variations,
+        data,
+      },
+    ];
   })
   .build();

--- a/packages/adapters/src/runners/source-runner.ts
+++ b/packages/adapters/src/runners/source-runner.ts
@@ -1,5 +1,5 @@
 import type { Cache, CacheOptions } from "@mojis/internal-utils";
-import type { AnySourceAdapter, InferHandlerOutput, PersistenceContext, PersistenceOptions } from "../builders/source-builder/types";
+import type { AnySourceAdapter, InferHandlerOutput, PersistenceOptions } from "../builders/source-builder/types";
 import type { AdapterContext } from "../global-types";
 import path, { join } from "node:path";
 import { arktypeParse } from "@mojis/internal-utils";

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -1,5 +1,6 @@
 import type { UrlFn } from "./builders/source-transformer-builder/types";
-import type { AdapterContext, BuiltinParser, PossibleUrls, UrlWithCache } from "./global-types";
+import type { AdapterContext, BuiltinParser, JoinPaths, PossibleUrls, UrlWithCache } from "./global-types";
+import path from "node:path";
 import { createCacheKeyFromUrl } from "@mojis/internal-utils";
 
 /**
@@ -125,4 +126,16 @@ export function buildContext<TContext extends AdapterContext, TExtraContext exte
   extraContext: TExtraContext,
 ): TContext & TExtraContext {
   return Object.assign({}, ctx, extraContext);
+}
+
+/**
+ * Type-safe path join function that preserves string literal types in the output
+ * when string literals are provided as input.
+ *
+ * @param segments - Path segments to join
+ * @returns Joined path with preserved literal type information when possible
+ */
+export function joinPath<Parts extends readonly string[]>(...segments: Parts): JoinPaths<Parts> {
+  // The actual implementation uses path.join but the return type is our literal type
+  return path.join(...segments) as JoinPaths<Parts>;
 }

--- a/packages/adapters/test/builders/source-adapter-handler.test.ts
+++ b/packages/adapters/test/builders/source-adapter-handler.test.ts
@@ -14,6 +14,9 @@ describe("adapter handler builder", () => {
     const builder = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
     });
     const handler = builder.build();
     expect(handler.adapterType).toBe("metadata");
@@ -23,6 +26,9 @@ describe("adapter handler builder", () => {
     const builder = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
     });
     const handler = builder.build();
     expect(handler.handlers).toHaveLength(0);
@@ -32,6 +38,9 @@ describe("adapter handler builder", () => {
     const builder = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
     });
 
     const handler = builder
@@ -52,6 +61,9 @@ describe("adapter handler builder", () => {
     const builder = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
     });
 
     const handler = builder
@@ -77,7 +89,14 @@ describe("adapter handler builder", () => {
   });
 
   it("maintains handler order", () => {
-    const builder = createSourceAdapter({ type: "metadata", transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
+    });
+
     const handler = builder
       .withTransform(
         (version) => version === "15.0",
@@ -105,7 +124,13 @@ describe("adapter handler builder", () => {
   });
 
   it("preserves adapter type across chain", () => {
-    const builder = createSourceAdapter({ type: "metadata", transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
+    });
     const handler = builder
       .withTransform(
         (version) => version === "15.0",
@@ -127,7 +152,14 @@ describe("adapter handler builder", () => {
   });
 
   it("allows chaining multiple onVersion calls", () => {
-    const builder = createSourceAdapter({ type: "metadata", transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA });
+    const builder = createSourceAdapter({
+      type: "metadata",
+      transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
+      persistence: {
+        schemas: {},
+      },
+    });
+
     const handler = builder
       .withTransform(
         (version) => version === "15.0",
@@ -165,6 +197,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: type({
         defaultValue: "boolean",
       }),
+      persistence: {
+        schemas: {},
+      },
     });
 
     const handler = builder
@@ -182,6 +217,9 @@ describe("adapter handler builder", () => {
     const builder = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: testSchema,
+      persistence: {
+        schemas: {},
+      },
     });
     const handler = builder.build();
 

--- a/packages/adapters/test/runners/composite-runner.test.ts
+++ b/packages/adapters/test/runners/composite-runner.test.ts
@@ -77,6 +77,9 @@ describe("run composite handler", () => {
       transformerOutputSchema: type({
         version: "string",
       }),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         () => true,
@@ -130,6 +133,9 @@ describe("run composite handler", () => {
       transformerOutputSchema: type({
         version: "string",
       }),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         () => true,
@@ -194,6 +200,9 @@ describe("run composite handler", () => {
         transformerOutputSchema: type({
           name: "string",
         }),
+        persistence: {
+          schemas: {},
+        },
       })
         .withTransform(
           () => true,

--- a/packages/adapters/test/runners/source-runner.test.ts
+++ b/packages/adapters/test/runners/source-runner.test.ts
@@ -27,6 +27,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     }).build();
 
     const result = await runSourceAdapter(handler, mockContext);
@@ -50,6 +53,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -98,6 +104,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -151,6 +160,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -203,6 +215,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -243,6 +258,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -287,6 +305,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type({}),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -336,6 +357,9 @@ describe("runSourceAdapter", () => {
     const handler = createSourceAdapter({
       type: "metadata",
       transformerOutputSchema: type("string | undefined"),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -383,6 +407,9 @@ describe("runSourceAdapter", () => {
       transformerOutputSchema: type({
         "page?": "string",
       }),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         predicate,
@@ -413,6 +440,9 @@ describe("runSourceAdapter", () => {
       transformerOutputSchema: type({
         page1: "string",
       }),
+      persistence: {
+        schemas: {},
+      },
     })
       .withTransform(
         predicate,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a structured, schema-driven persistence configuration with named schemas supporting customizable file patterns, paths, and validation.
  - Added type-safe utilities for joining file paths and extracting parameters from file path patterns.

- **Refactor**
  - Replaced the previous persistence schema and options system with a new `persistence` object supporting multiple schemas and enhanced type safety.
  - Renamed persistence methods to `toPersistenceOperations` and updated signatures to use schema references and parameterized file paths.
  - Updated handler and runner logic to utilize the new persistence configuration and mapping functions.
  - Replaced Node.js path join with a typed `joinPath` utility preserving string literal types.

- **Bug Fixes**
  - Improved error handling for missing file path parameters during persistence operations.

- **Tests**
  - Updated test cases to include the new persistence schema structure and align with updated adapter configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->