### PR TITLE
refactor: set fallback on adapter level

### DIFF
--- a/.changeset/twenty-ears-fry.md
+++ b/.changeset/twenty-ears-fry.md
@@ -1,0 +1,5 @@
+---
+"@mojis/adapters": minor
+---
+
+refactor: move fallback to be on creator

--- a/packages/adapters/src/builders/source-builder/builder.ts
+++ b/packages/adapters/src/builders/source-builder/builder.ts
@@ -1,7 +1,6 @@
 import type { type } from "arktype";
 import type {
   SourceAdapterType,
-  UnsetMarker,
 } from "../../global-types";
 import type { AnySourceTransformer } from "../source-transformer-builder/types";
 import type {
@@ -22,7 +21,7 @@ function internalCreateSourceAdapterBuilder<
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
-    _fallback: UnsetMarker;
+    _fallback: TTransformerOutputSchema["infer"];
     _persistence: TPersistence;
     _persistenceMapFn: any;
   }> {
@@ -30,7 +29,7 @@ function internalCreateSourceAdapterBuilder<
     adapterType: initDef.adapterType,
     transformerOutputSchema: initDef.transformerOutputSchema,
     handlers: [],
-    fallback: () => {},
+    fallback: initDef.fallback,
     persistence: initDef.persistence ?? {} as PersistenceContext,
     persistenceMapFn: () => { return []; },
 
@@ -49,12 +48,6 @@ function internalCreateSourceAdapterBuilder<
           ..._def.handlers,
           [userPredicate, sourceTransformer],
         ],
-      }) as SourceAdapterBuilder<any>;
-    },
-    fallback(userFn) {
-      return internalCreateSourceAdapterBuilder({
-        ..._def,
-        fallback: userFn,
       }) as SourceAdapterBuilder<any>;
     },
     toPersistenceOperations(userFn) {
@@ -77,6 +70,7 @@ export interface CreateSourceAdapterBuilderOptions<
   type: TAdapterType;
   transformerOutputSchema: TTransformerOutputSchema;
   persistence: TPersistence;
+  fallback: TTransformerOutputSchema["infer"];
 }
 
 export function createSourceAdapter<
@@ -90,16 +84,17 @@ export function createSourceAdapter<
     TPersistence
   >,
 ): SourceAdapterBuilder<{
+    _fallback: TTransformerOutputSchema["infer"];
     _adapterType: TAdapterType;
     _handlers: [PredicateFn, AnySourceTransformer][];
     _transformerOutputSchema: TTransformerOutputSchema;
-    _fallback: UnsetMarker;
     _persistence: TPersistence;
     _persistenceMapFn: any;
   }> {
   return internalCreateSourceAdapterBuilder<TAdapterType, TTransformerOutputSchema, TPersistence>({
     adapterType: opts.type,
     transformerOutputSchema: opts.transformerOutputSchema,
+    fallback: opts.fallback,
     persistence: opts.persistence,
   });
 }

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -158,23 +158,17 @@ export type PredicateFn = (version: string) => boolean;
 export interface AnyBuiltSourceAdapterParams {
   adapterType: SourceAdapterType;
   handlers: [PredicateFn, AnySourceTransformer][];
-  fallback?: FallbackFn<any>;
+  fallback: any;
   transformerOutputSchema: type.Any;
   persistence: PersistenceContext;
   persistenceMapFn: any;
 }
 
-export type FallbackFn<TOut> = () => TOut;
-
 export interface SourceAdapter<TParams extends AnyBuiltSourceAdapterParams> {
   adapterType: TParams["adapterType"];
   handlers: TParams["handlers"];
   transformerOutputSchema: TParams["transformerOutputSchema"];
-  fallback?: FallbackFn<
-    TParams["transformerOutputSchema"] extends type.Any
-      ? TParams["transformerOutputSchema"]["infer"]
-      : any
-  >;
+  fallback: TParams["transformerOutputSchema"]["infer"];
   persistence: TParams["persistence"];
   persistenceMapFn: PersistenceMapFn<TParams["persistence"], TParams["transformerOutputSchema"]["infer"], TParams["persistenceMapFn"]>;
 }

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -1,10 +1,8 @@
 import type { type } from "arktype";
 import type {
-  ErrorMessage,
   MaybePromise,
   MergeTuple,
   SourceAdapterType,
-  UnsetMarker,
 } from "../../global-types";
 import type {
   AnySourceTransformer,

--- a/packages/adapters/src/builders/source-builder/types.ts
+++ b/packages/adapters/src/builders/source-builder/types.ts
@@ -104,19 +104,6 @@ export interface SourceAdapterBuilder<
     _persistenceMapFn: TParams["_persistenceMapFn"];
   }>;
 
-  fallback: <TOut extends TParams["_transformerOutputSchema"] extends type.Any ? TParams["_transformerOutputSchema"]["infer"] : any>(
-    fn: TParams["_fallback"] extends UnsetMarker
-      ? FallbackFn<TOut>
-      : ErrorMessage<"fallback is already set">,
-  ) => SourceAdapterBuilder<{
-    _fallback: TOut;
-    _handlers: TParams["_handlers"];
-    _transformerOutputSchema: TParams["_transformerOutputSchema"];
-    _adapterType: TParams["_adapterType"];
-    _persistence: TParams["_persistence"];
-    _persistenceMapFn: TParams["_persistenceMapFn"];
-  }>;
-
   toPersistenceOperations: <
     TIn extends TParams["_transformerOutputSchema"]["infer"],
     TOut extends ValidSchemaOp<TParams["_persistence"]>,

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -27,6 +27,10 @@ const builder = createSourceAdapter({
     groups: EMOJI_GROUPS_SCHEMA,
     emojis: GROUPED_BY_GROUP_EMOJI_METADATA_SCHEMA,
   }),
+  fallback: {
+    groups: [],
+    emojis: {},
+  },
   persistence: {
     schemas: {
       groups: {
@@ -168,12 +172,6 @@ export const handler = builder
         });
     },
   )
-  .fallback(() => {
-    return {
-      emojis: {},
-      groups: [],
-    };
-  })
   .toPersistenceOperations((references, data) => {
     return [
       {

--- a/packages/adapters/src/handlers/source/sequences.ts
+++ b/packages/adapters/src/handlers/source/sequences.ts
@@ -38,6 +38,10 @@ const builder = createSourceAdapter({
     sequences: EMOJI_SEQUENCE_SCHEMA.array(),
     zwj: EMOJI_SEQUENCE_SCHEMA.array(),
   }),
+  fallback: {
+    sequences: [],
+    zwj: [],
+  },
   persistence: {
     schemas: {
       sequences: {
@@ -143,12 +147,6 @@ export const handler = builder
         return sequences;
       }),
   )
-  .fallback(() => {
-    return {
-      sequences: [],
-      zwj: [],
-    };
-  })
   .toPersistenceOperations((references, data) => {
     return [
       {

--- a/packages/adapters/src/handlers/source/unicode-names.ts
+++ b/packages/adapters/src/handlers/source/unicode-names.ts
@@ -15,6 +15,7 @@ const builder = createSourceAdapter({
   transformerOutputSchema: type({
     "[string]": "string",
   }),
+  fallback: {},
   persistence: {
     schemas: {
       unicodeNames: {
@@ -64,9 +65,6 @@ export const handler = builder
         return transformed;
       }),
   )
-  .fallback(() => {
-    return {};
-  })
   .toPersistenceOperations((references, data) => {
     return [
       {

--- a/packages/adapters/src/handlers/source/variations.ts
+++ b/packages/adapters/src/handlers/source/variations.ts
@@ -9,6 +9,7 @@ const UNSUPPORTED_VARIATION_VERSIONS = ["1.0", "2.0", "3.0", "4.0"];
 const builder = createSourceAdapter({
   type: "variations",
   transformerOutputSchema: EMOJI_VARIATION_SCHEMA.array(),
+  fallback: [],
   persistence: {
     schemas: {
       variations: {
@@ -72,9 +73,6 @@ export const handler = builder
         return transformed;
       }),
   )
-  .fallback(() => {
-    return [];
-  })
   .toPersistenceOperations((references, data) => {
     return [
       {

--- a/packages/adapters/src/runners/source-runner.ts
+++ b/packages/adapters/src/runners/source-runner.ts
@@ -33,10 +33,9 @@ export async function runSourceAdapter<
 
   assertValidHandler(handler);
 
-  // TODO: make this default to true
   const shouldWrite = options?.write ?? true;
 
-  let output = (typeof handler.fallback == "function" && handler.fallback != null) ? handler.fallback() : undefined;
+  let output = handler.fallback;
 
   for (const [predicate, sourceTransformer] of handler.handlers) {
     if (!predicate(ctx.emoji_version)) {

--- a/packages/adapters/test/builders/source-adapter-handler.test.ts
+++ b/packages/adapters/test/builders/source-adapter-handler.test.ts
@@ -17,6 +17,9 @@ describe("adapter handler builder", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {
+        name: "default",
+      },
     });
     const handler = builder.build();
     expect(handler.adapterType).toBe("metadata");
@@ -29,6 +32,9 @@ describe("adapter handler builder", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {
+        name: "default",
+      },
     });
     const handler = builder.build();
     expect(handler.handlers).toHaveLength(0);
@@ -40,6 +46,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        name: "default",
       },
     });
 
@@ -63,6 +72,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        name: "default",
       },
     });
 
@@ -94,6 +106,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        name: "default",
       },
     });
 
@@ -130,6 +145,9 @@ describe("adapter handler builder", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {
+        name: "default",
+      },
     });
     const handler = builder
       .withTransform(
@@ -157,6 +175,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: DUMMY_ARKTYPE_SCHEMA,
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        name: "default",
       },
     });
 
@@ -200,14 +221,13 @@ describe("adapter handler builder", () => {
       persistence: {
         schemas: {},
       },
+      fallback: fallbackData,
     });
 
     const handler = builder
-      .fallback(() => fallbackData)
       .build();
 
-    expect(handler.fallback).toBeTypeOf("function");
-    expect(handler.fallback?.()).toEqual(fallbackData);
+    expect(handler.fallback).toEqual(fallbackData);
   });
 
   it("adds output schema for validation", () => {
@@ -219,6 +239,9 @@ describe("adapter handler builder", () => {
       transformerOutputSchema: testSchema,
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        name: "default",
       },
     });
     const handler = builder.build();

--- a/packages/adapters/test/runners/composite-runner.test.ts
+++ b/packages/adapters/test/runners/composite-runner.test.ts
@@ -80,6 +80,9 @@ describe("run composite handler", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {
+        version: "1.0",
+      },
     })
       .withTransform(
         () => true,
@@ -135,6 +138,9 @@ describe("run composite handler", () => {
       }),
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        version: "1.0",
       },
     })
       .withTransform(
@@ -202,6 +208,9 @@ describe("run composite handler", () => {
         }),
         persistence: {
           schemas: {},
+        },
+        fallback: {
+          name: "default",
         },
       })
         .withTransform(

--- a/packages/adapters/test/runners/source-runner.test.ts
+++ b/packages/adapters/test/runners/source-runner.test.ts
@@ -30,6 +30,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     }).build();
 
     const result = await runSourceAdapter(handler, mockContext);
@@ -56,6 +57,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -107,6 +109,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -163,6 +166,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -218,6 +222,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -261,6 +266,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -308,6 +314,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -360,6 +367,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: undefined,
     })
       .withTransform(
         (version: string) => version === "15.0",
@@ -410,6 +418,7 @@ describe("runSourceAdapter", () => {
       persistence: {
         schemas: {},
       },
+      fallback: {},
     })
       .withTransform(
         predicate,
@@ -442,6 +451,9 @@ describe("runSourceAdapter", () => {
       }),
       persistence: {
         schemas: {},
+      },
+      fallback: {
+        page1: "default",
       },
     })
       .withTransform(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated how fallback values are provided in adapters: fallback is now set directly as a required property during adapter creation, rather than via a method or function.
  - Simplified configuration for source adapters by removing the ability to set or override fallback values after creation.
- **Tests**
  - Updated tests to reflect the new fallback configuration approach, ensuring consistency with the revised adapter setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->