### PR TITLE
feat: add basic validate cmd

### DIFF
--- a/.changeset/evil-singers-film.md
+++ b/.changeset/evil-singers-film.md
@@ -1,0 +1,5 @@
+---
+"@mojis/cli": minor
+---
+
+feat: add basic validation function

--- a/packages/cli/src/cli-utils.ts
+++ b/packages/cli/src/cli-utils.ts
@@ -1,5 +1,6 @@
 import type { Arguments } from "yargs-parser";
 import type { CLIGenerateCmdOptions } from "./cmd/generate";
+import type { CLIValidateCmdOptions } from "./cmd/validate";
 import process from "node:process";
 import {
   bgGreen,
@@ -17,11 +18,13 @@ type CLICommand =
   | "help"
   | "version"
   | "emoji-versions"
-  | "generate";
+  | "generate"
+  | "validate";
 
 const SUPPORTED_COMMANDS = new Set<CLICommand>([
   "generate",
   "emoji-versions",
+  "validate",
 ]);
 
 export type CLIArguments<T extends Record<string, unknown>> = Arguments & T;
@@ -133,6 +136,7 @@ export async function runCommand(cmd: CLICommand, flags: Arguments): Promise<voi
           "Commands": [
             ["generate", "Generate emoji data for the specified versions."],
             ["emoji-versions", "Print all emoji versions available."],
+            ["validate", "Validate generated emoji data."],
           ],
           "Global Flags": [
             ["--force", "Force the operation to run, even if it's not needed."],
@@ -158,6 +162,15 @@ export async function runCommand(cmd: CLICommand, flags: Arguments): Promise<voi
       });
       break;
     }
+    case "validate": {
+      const { runValidate } = await import("./cmd/validate");
+      const versions = flags._.slice(3) as string[];
+      await runValidate({
+        versions,
+        flags: flags as CLIValidateCmdOptions["flags"],
+      });
+      break;
+    }
     case "generate": {
       const { runGenerate } = await import("./cmd/generate");
       const versions = flags._.slice(3) as string[];
@@ -177,7 +190,7 @@ export function parseFlags(args: string[]) {
     configuration: {
       "parse-positional-numbers": false,
     },
-    string: ["output-dir"],
+    string: ["output-dir", "input-dir"],
     array: ["generators", "shortcode-providers"],
     boolean: ["force", "drafts"],
     default: {

--- a/packages/cli/src/cmd/validate.ts
+++ b/packages/cli/src/cmd/validate.ts
@@ -1,0 +1,30 @@
+import type { CLIArguments } from "../cli-utils";
+import { green } from "farver/fast";
+import { printHelp } from "../cli-utils";
+
+export interface CLIValidateCmdOptions {
+  flags: CLIArguments<{
+    inputDir: string;
+  }>;
+  versions: string[];
+}
+
+export async function runValidate({ versions: _providedVersions, flags }: CLIValidateCmdOptions) {
+  if (flags?.help || flags?.h) {
+    printHelp({
+      headline: "Validate generated Emoji Data.",
+      commandName: "mojis validate",
+      usage: "<...versions> [...flags]",
+      tables: {
+        Flags: [
+          ["--input-dir", "Specify the input directory."],
+          ["--help (-h)", "See all available flags."],
+        ],
+      },
+    });
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`  ${green("validating emoji data...")}`);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new "validate" command to the CLI tool, allowing users to initiate basic validation of emoji data.
	- Introduced support for an "input-dir" flag with the "validate" command.
	- Included help documentation for the new "validate" command within the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->