### PR TITLE
refactor: remove typecheck configurations and related tsconfig files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,12 @@ jobs:
       - name: lint
         run: pnpm lint
 
+      - name: typecheck
+        run: pnpm typecheck
+
       - name: test
         run: pnpm test --coverage
 
-      - name: typecheck
-        run: pnpm typecheck
 
       - name: upload coverage reports to codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0

--- a/packages/adapters/tsconfig.test.json
+++ b/packages/adapters/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/packages/internal-utils/tsconfig.test.json
+++ b/packages/internal-utils/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/packages/parsers/tsconfig.test.json
+++ b/packages/parsers/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/packages/schemas/tsconfig.test.json
+++ b/packages/schemas/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/packages/versions/tsconfig.test.json
+++ b/packages/versions/tsconfig.test.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["**/*.test-d.*"]
-}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,12 +47,6 @@ export default defineConfig({
           name: "internal-utils",
           environment: "node",
           mockReset: true,
-          typecheck: {
-            checker: "tsc",
-            enabled: true,
-            include: ["./packages/internal-utils/**/*.{test,spec}-d.?(c|m)[jt]s?(x)"],
-            tsconfig: "./packages/internal-utils/tsconfig.test.json"
-          }
         },
         esbuild: { target: "es2020" },
         resolve: { alias: aliases },
@@ -65,12 +59,6 @@ export default defineConfig({
           name: "adapters",
           environment: "node",
           mockReset: true,
-          typecheck: {
-            checker: "tsc",
-            enabled: true,
-            include: ["./packages/adapters/**/*.{test,spec}-d.?(c|m)[jt]s?(x)"],
-            tsconfig: "./packages/adapters/tsconfig.test.json"
-          }
         },
         esbuild: { target: "es2020" },
         resolve: { alias: aliases },
@@ -82,12 +70,6 @@ export default defineConfig({
           name: "cli",
           environment: "node",
           mockReset: true,
-          typecheck: {
-            checker: "tsc",
-            enabled: true,
-            include: ["./packages/cli/**/*.{test,spec}-d.?(c|m)[jt]s?(x)"],
-            tsconfig: "./packages/cli/tsconfig.test.json"
-          }
         },
         esbuild: { target: "es2020" },
         resolve: { alias: aliases },
@@ -99,12 +81,6 @@ export default defineConfig({
           name: "parsers",
           environment: "node",
           mockReset: true,
-          typecheck: {
-            checker: "tsc",
-            enabled: true,
-            include: ["./packages/parsers/**/*.{test,spec}-d.?(c|m)[jt]s?(x)"],
-            tsconfig: "./packages/parsers/tsconfig.test.json"
-          }
         },
         esbuild: { target: "es2020" },
         resolve: { alias: aliases },
@@ -116,12 +92,6 @@ export default defineConfig({
           name: "schemas",
           environment: "node",
           mockReset: true,
-          typecheck: {
-            checker: "tsc",
-            enabled: true,
-            include: ["./packages/schemas/**/*.{test,spec}-d.?(c|m)[jt]s?(x)"],
-            tsconfig: "./packages/schemas/tsconfig.test.json"
-          }
         },
         esbuild: { target: "es2020" },
         resolve: { alias: aliases },


### PR DESCRIPTION
By doing this we are reducing the amount of Typechecks we are running down from 2, to 1.

This will speedup the CI pipeline by a small margin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed package-specific TypeScript test configuration files.
	- Updated test configuration to eliminate type checking for test declaration files in several packages.
	- Adjusted CI workflow to change the order of type checking in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->