### PR TITLE
refactor: update unicode proxy URLs to remove 'proxy' segment

### DIFF
--- a/.changeset/wicked-rivers-move.md
+++ b/.changeset/wicked-rivers-move.md
@@ -1,0 +1,7 @@
+---
+"@mojis/adapters": patch
+"@mojis/versions": patch
+"@mojis/parsers": patch
+---
+
+switch proxy endpoint

--- a/packages/adapters/src/handlers/source/metadata.ts
+++ b/packages/adapters/src/handlers/source/metadata.ts
@@ -61,7 +61,7 @@ export const handler = builder
       return builder
         .urls((ctx) => {
           return {
-            url: `https://unicode-proxy.ucdjs.dev/proxy/emoji/${ctx.emoji_version}/emoji-test.txt`,
+            url: `https://unicode-proxy.ucdjs.dev/emoji/${ctx.emoji_version}/emoji-test.txt`,
             cacheKey: `v${ctx.emoji_version}/metadata`,
           };
         })

--- a/packages/adapters/src/handlers/source/sequences.ts
+++ b/packages/adapters/src/handlers/source/sequences.ts
@@ -72,12 +72,12 @@ export const handler = builder
         return [
           {
             key: "sequences",
-            url: `https://unicode-proxy.ucdjs.dev/proxy/emoji/${emoji_version}/emoji-sequences.txt`,
+            url: `https://unicode-proxy.ucdjs.dev/emoji/${emoji_version}/emoji-sequences.txt`,
             cacheKey: `v${emoji_version}/sequences`,
           },
           {
             key: "zwj",
-            url: `https://unicode-proxy.ucdjs.dev/proxy/emoji/${emoji_version}/emoji-zwj-sequences.txt`,
+            url: `https://unicode-proxy.ucdjs.dev/emoji/${emoji_version}/emoji-zwj-sequences.txt`,
             cacheKey: `v${emoji_version}/zwj-sequences`,
           },
         ];

--- a/packages/adapters/src/handlers/source/unicode-names.ts
+++ b/packages/adapters/src/handlers/source/unicode-names.ts
@@ -3,11 +3,11 @@ import { createSourceAdapter } from "../../builders/source-builder/builder";
 import { joinPath } from "../../utils";
 
 const MAPPINGS = {
-  "1.0": "https://unicode-proxy.ucdjs.dev/proxy/1.1-Update/UnicodeData-1.1.5.txt",
-  "2.0": "https://unicode-proxy.ucdjs.dev/proxy/2.0-Update/UnicodeData-2.0.14.txt",
-  "3.0": "https://unicode-proxy.ucdjs.dev/proxy/3.0-Update1/UnicodeData-3.0.1.txt",
-  "4.0": "https://unicode-proxy.ucdjs.dev/proxy/4.0-Update1/UnicodeData-4.0.1.txt",
-  "13.1": "https://unicode-proxy.ucdjs.dev/proxy/13.0.0/ucd/UnicodeData.txt",
+  "1.0": "https://unicode-proxy.ucdjs.dev/1.1-Update/UnicodeData-1.1.5.txt",
+  "2.0": "https://unicode-proxy.ucdjs.dev/2.0-Update/UnicodeData-2.0.14.txt",
+  "3.0": "https://unicode-proxy.ucdjs.dev/3.0-Update1/UnicodeData-3.0.1.txt",
+  "4.0": "https://unicode-proxy.ucdjs.dev/4.0-Update1/UnicodeData-4.0.1.txt",
+  "13.1": "https://unicode-proxy.ucdjs.dev/13.0.0/ucd/UnicodeData.txt",
 } as Record<string, string>;
 
 const builder = createSourceAdapter({
@@ -38,7 +38,7 @@ export const handler = builder
     (builder) => builder
       .urls((ctx) => {
         return {
-          url: MAPPINGS[ctx.emoji_version] || `https://unicode-proxy.ucdjs.dev/proxy/${ctx.emoji_version}.0/ucd/UnicodeData.txt`,
+          url: MAPPINGS[ctx.emoji_version] || `https://unicode-proxy.ucdjs.dev/${ctx.emoji_version}.0/ucd/UnicodeData.txt`,
           cacheKey: `v${ctx.emoji_version}/unicode-names`,
         };
       })

--- a/packages/adapters/src/handlers/source/variations.ts
+++ b/packages/adapters/src/handlers/source/variations.ts
@@ -31,13 +31,13 @@ export const handler = builder
       .urls((ctx) => {
         if (lte(ctx.unicode_version, "12.1")) {
           return {
-            url: `https://unicode-proxy.ucdjs.dev/proxy/emoji/${ctx.emoji_version}/emoji-variation-sequences.txt`,
+            url: `https://unicode-proxy.ucdjs.dev/emoji/${ctx.emoji_version}/emoji-variation-sequences.txt`,
             cacheKey: `v${ctx.emoji_version}/variations`,
           };
         }
 
         return {
-          url: `https://unicode-proxy.ucdjs.dev/proxy/${ctx.unicode_version}.0/ucd/emoji/emoji-variation-sequences.txt`,
+          url: `https://unicode-proxy.ucdjs.dev/${ctx.unicode_version}.0/ucd/emoji/emoji-variation-sequences.txt`,
           cacheKey: `v${ctx.emoji_version}/variations`,
         };
       })

--- a/packages/adapters/test/handlers/source/metadata.test.ts
+++ b/packages/adapters/test/handlers/source/metadata.test.ts
@@ -22,7 +22,7 @@ describe("metadata adapter handler", () => {
     });
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
     ]);
 
     const result = await runSourceAdapter(metadataHandler, mockContext);
@@ -143,7 +143,7 @@ describe("metadata adapter handler", () => {
 `;
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
     ]);
 
     const result = await runSourceAdapter(metadataHandler, mockContext);
@@ -166,7 +166,7 @@ describe("metadata adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => HttpResponse.text("")],
     ]);
 
     const result = await runSourceAdapter(metadataHandler, mockContext);
@@ -179,7 +179,7 @@ describe("metadata adapter handler", () => {
   it("should handle network errors", async () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
-    mockFetch(`GET https://unicode-proxy.ucdjs.dev/proxy/emoji/${mockContext.emoji_version}/emoji-test.txt`, () => {
+    mockFetch(`GET https://unicode-proxy.ucdjs.dev/emoji/${mockContext.emoji_version}/emoji-test.txt`, () => {
       return HttpResponse.error();
     });
 
@@ -200,7 +200,7 @@ describe("metadata adapter handler", () => {
 
     let fetchCount = 0;
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => {
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => {
         fetchCount++;
         return HttpResponse.text(mockEmojiTest);
       }],
@@ -225,7 +225,7 @@ describe("metadata adapter handler", () => {
     });
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
     ]);
 
     await expect(runSourceAdapter(metadataHandler, mockContext))
@@ -242,7 +242,7 @@ describe("metadata adapter handler", () => {
 `;
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-test.txt", () => HttpResponse.text(mockEmojiTest)],
     ]);
 
     await expect(runSourceAdapter(metadataHandler, mockContext))

--- a/packages/adapters/test/handlers/source/sequences.test.ts
+++ b/packages/adapters/test/handlers/source/sequences.test.ts
@@ -48,11 +48,11 @@ describe("sequences adapter handler", () => {
 
     mockFetch([
       [
-        "GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-sequences.txt",
+        "GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-sequences.txt",
         () => HttpResponse.text(mockedSequences),
       ],
       [
-        "GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-zwj-sequences.txt",
+        "GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-zwj-sequences.txt",
         () => HttpResponse.text(),
       ],
     ]);
@@ -128,11 +128,11 @@ describe("sequences adapter handler", () => {
 
     mockFetch([
       [
-        "GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-sequences.txt",
+        "GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-sequences.txt",
         () => HttpResponse.text(),
       ],
       [
-        "GET https://unicode-proxy.ucdjs.dev/proxy/emoji/15.0/emoji-zwj-sequences.txt",
+        "GET https://unicode-proxy.ucdjs.dev/emoji/15.0/emoji-zwj-sequences.txt",
         () => HttpResponse.text(mockedSequences),
       ],
     ]);

--- a/packages/adapters/test/handlers/source/unicode-names.test.ts
+++ b/packages/adapters/test/handlers/source/unicode-names.test.ts
@@ -15,7 +15,7 @@ describe("unicode-names adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("1F600;GRINNING FACE")],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("1F600;GRINNING FACE")],
     ]);
 
     const result = await runSourceAdapter(unicodeNamesHandler, mockContext);
@@ -28,7 +28,7 @@ describe("unicode-names adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/1.1-Update/UnicodeData-1.1.5.txt", () => HttpResponse.text("1F600;GRINNING FACE")],
+      ["GET https://unicode-proxy.ucdjs.dev/1.1-Update/UnicodeData-1.1.5.txt", () => HttpResponse.text("1F600;GRINNING FACE")],
     ]);
 
     const result = await runSourceAdapter(unicodeNamesHandler, { ...mockContext, emoji_version: "1.0" });
@@ -41,7 +41,7 @@ describe("unicode-names adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text(
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text(
         "1F600;GRINNING FACE\n"
         + "1F601;GRINNING FACE WITH SMILING EYES\n"
         + "1F602;FACE WITH TEARS OF JOY",
@@ -60,7 +60,7 @@ describe("unicode-names adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("1F600")],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("1F600")],
     ]);
 
     await expect(runSourceAdapter(unicodeNamesHandler, mockContext))
@@ -72,7 +72,7 @@ describe("unicode-names adapter handler", () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/UnicodeData.txt", () => HttpResponse.text("")],
     ]);
 
     const result = await runSourceAdapter(unicodeNamesHandler, mockContext);
@@ -82,7 +82,7 @@ describe("unicode-names adapter handler", () => {
   it("should handle network errors", async () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
-    mockFetch(`GET https://unicode-proxy.ucdjs.dev/proxy/${mockContext.emoji_version}.0/ucd/UnicodeData.txt`, () => {
+    mockFetch(`GET https://unicode-proxy.ucdjs.dev/${mockContext.emoji_version}.0/ucd/UnicodeData.txt`, () => {
       return HttpResponse.error();
     });
 
@@ -97,7 +97,7 @@ describe("unicode-names adapter handler", () => {
 
     let fetchCount = 0;
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/UnicodeData.txt", () => {
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/UnicodeData.txt", () => {
         fetchCount++;
         return HttpResponse.text("1F600;GRINNING FACE");
       }],

--- a/packages/adapters/test/handlers/source/variations.test.ts
+++ b/packages/adapters/test/handlers/source/variations.test.ts
@@ -22,7 +22,7 @@ describe("variations adapter handler", () => {
     });
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
     ]);
 
     const result = await runSourceAdapter(variationsHandler, mockContext);
@@ -66,7 +66,7 @@ FE0E ; text style     # VS-15
 `;
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/12.1/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/12.1/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
     ]);
 
     const result = await runSourceAdapter(variationsHandler, {
@@ -100,7 +100,7 @@ FE0E ; text style     # VS-15
     const { runSourceAdapter } = await setupAdapterTest();
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text("")],
     ]);
 
     const result = await runSourceAdapter(variationsHandler, mockContext);
@@ -110,7 +110,7 @@ FE0E ; text style     # VS-15
   it("should handle network errors", async () => {
     const { runSourceAdapter } = await setupAdapterTest();
 
-    mockFetch(`GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt`, () => {
+    mockFetch(`GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt`, () => {
       return HttpResponse.error();
     });
 
@@ -125,7 +125,7 @@ FE0E ; text style     # VS-15
 
     let fetchCount = 0;
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => {
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => {
         fetchCount++;
         return HttpResponse.text("FE0E ; text style     # VS-15");
       }],
@@ -148,7 +148,7 @@ invalid-line
 `;
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
     ]);
 
     await expect(runSourceAdapter(variationsHandler, mockContext))
@@ -166,7 +166,7 @@ invalid-line
     });
 
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
+      ["GET https://unicode-proxy.ucdjs.dev/15.0.0/ucd/emoji/emoji-variation-sequences.txt", () => HttpResponse.text(mockVariations)],
     ]);
 
     await expect(runSourceAdapter(variationsHandler, mockContext))

--- a/packages/parsers/scripts/update-parser-fixtures.ts
+++ b/packages/parsers/scripts/update-parser-fixtures.ts
@@ -11,7 +11,7 @@ interface Entry {
 }
 
 async function run() {
-  const rootResponse = await fetch("https://unicode-proxy.ucdjs.dev/proxy/emoji/");
+  const rootResponse = await fetch("https://unicode-proxy.ucdjs.dev/emoji/");
 
   if (!rootResponse.ok) {
     throw new Error("failed to fetch root entry");
@@ -21,7 +21,7 @@ async function run() {
   await mkdir(root, { recursive: true });
 
   async function processDirectory(entry: Entry, basePath: string) {
-    const dirResponse = await fetch(`https://unicode-proxy.ucdjs.dev/proxy${entry.path}`);
+    const dirResponse = await fetch(`https://unicode-proxy.ucdjs.dev${entry.path}`);
     const dirEntries: Entry[] = await dirResponse.json();
 
     const fileEntries = dirEntries.filter(
@@ -41,7 +41,7 @@ async function run() {
 
         await mkdir(new URL(type, root), { recursive: true });
 
-        const content = await fetch(`https://unicode-proxy.ucdjs.dev/proxy${fullPath}`).then((res) => res.text());
+        const content = await fetch(`https://unicode-proxy.ucdjs.dev${fullPath}`).then((res) => res.text());
         await writeFile(
           new URL(`${type}/v${version.toString()}${fileExt}`, root),
           content,

--- a/packages/versions/src/api.ts
+++ b/packages/versions/src/api.ts
@@ -23,8 +23,8 @@ export interface DraftVersion {
  */
 export async function getCurrentDraftVersion(): Promise<DraftVersion | null> {
   const [draftText, emojiText] = await Promise.all([
-    "https://unicode-proxy.ucdjs.dev/proxy/draft/ReadMe.txt",
-    "https://unicode-proxy.ucdjs.dev/proxy/draft/emoji/ReadMe.txt",
+    "https://unicode-proxy.ucdjs.dev/draft/ReadMe.txt",
+    "https://unicode-proxy.ucdjs.dev/draft/emoji/ReadMe.txt",
   ].map(async (url) => {
     const res = await fetch(url);
 
@@ -72,8 +72,8 @@ export async function getCurrentDraftVersion(): Promise<DraftVersion | null> {
  */
 export async function getAllEmojiVersions(): Promise<EmojiSpecRecord[]> {
   const [rootResult, emojiResult] = await Promise.allSettled([
-    "https://unicode-proxy.ucdjs.dev/proxy/",
-    "https://unicode-proxy.ucdjs.dev/proxy/emoji/",
+    "https://unicode-proxy.ucdjs.dev/",
+    "https://unicode-proxy.ucdjs.dev/emoji/",
   ].map(async (url) => {
     const res = await fetch(url);
 

--- a/packages/versions/test/api.test.ts
+++ b/packages/versions/test/api.test.ts
@@ -19,8 +19,8 @@ describe("all emoji versions", () => {
 
   it("should throw if fetch returns invalid data", async () => {
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/", () => HttpResponse.text("Not Found", { status: 400 })],
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/", () => HttpResponse.text("Not Found", { status: 400 })],
+      ["GET https://unicode-proxy.ucdjs.dev/", () => HttpResponse.text("Not Found", { status: 400 })],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/", () => HttpResponse.text("Not Found", { status: 400 })],
     ]);
 
     await expect(() => getAllEmojiVersions()).rejects.toThrow("failed to fetch root or emoji page");
@@ -28,8 +28,8 @@ describe("all emoji versions", () => {
 
   it("should throw if empty data is returned", async () => {
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/", () => HttpResponse.text("")],
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/emoji/", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/emoji/", () => HttpResponse.text("")],
     ]);
 
     await expect(() => getAllEmojiVersions()).rejects.toThrow("failed to fetch root or emoji page");
@@ -39,8 +39,8 @@ describe("all emoji versions", () => {
 describe("draft", () => {
   it("returns draft versions when fetches succeed and versions match", async () => {
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.1")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.1")],
     ]);
 
     const result = await getCurrentDraftVersion();
@@ -52,8 +52,8 @@ describe("draft", () => {
 
   it("should throw when versions do not match", async () => {
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/ReadMe.txt", () => HttpResponse.text("Version 15.1.0 of the Unicode Standard")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
     ]);
 
     await expect(() => getCurrentDraftVersion()).rejects.toThrow("draft versions do not match");
@@ -64,13 +64,13 @@ describe("draft", () => {
       return new HttpResponse("Not Found", { status: 404 });
     });
 
-    await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to fetch https://unicode-proxy.ucdjs.dev/proxy/draft/ReadMe.txt: 404");
+    await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to fetch https://unicode-proxy.ucdjs.dev/draft/ReadMe.txt: 404");
   });
 
   it("should throw if emoji version is invalid", async () => {
     mockFetch([
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/ReadMe.txt", () => HttpResponse.text("")],
-      ["GET https://unicode-proxy.ucdjs.dev/proxy/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/ReadMe.txt", () => HttpResponse.text("")],
+      ["GET https://unicode-proxy.ucdjs.dev/draft/emoji/ReadMe.txt", () => HttpResponse.text("Unicode Emoji, Version 15.0")],
     ]);
 
     await expect(() => getCurrentDraftVersion()).rejects.toThrow("failed to extract draft version");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated all emoji and Unicode data fetch endpoints to use new URLs without the "/proxy" path segment, ensuring continued access to required resources.

- **Tests**
  - Adjusted all test cases to use the updated endpoint URLs, maintaining alignment with the new fetch locations.

- **Chores**
  - Updated internal scripts and supporting packages to match the new endpoint format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->